### PR TITLE
Add mentioned build command to the root package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "packageManager": "pnpm@8.15.5",
   "scripts": {
     "format": "prettier --write .",
-    "lint": "prettier --check ."
+    "lint": "prettier --check .",
+    "build": "tsc -b"
   }
 }


### PR DESCRIPTION
It was mentioned that for building the project we should run `pnpm build` command in the root directory of the project but unfortunately there is not build command in `package.json` file.
After adding the line to package.json the project runs successfully.

The command mentioned [README file](https://github.com/masslbs/Tennessine/blob/main/README.md)