### PR TITLE
Made recoverMessageAddress method synchronous

### DIFF
--- a/packages/client/src/stream.ts
+++ b/packages/client/src/stream.ts
@@ -39,7 +39,7 @@ export class ReadableEventStream {
           const requestId = pushReq.requestId;
           for (const anyEvt of pushReq.events) {
             const event = schema.ShopEvent.decode(anyEvt.event.value);
-            const signer = await recoverMessageAddress({
+            const signer = recoverMessageAddress({
               message: { raw: anyEvt.event.value },
               signature: anyEvt.signature,
             });

--- a/packages/client/test/stream.test.ts
+++ b/packages/client/test/stream.test.ts
@@ -43,7 +43,7 @@ class MockClient {
   }
 }
 
-describe("Stream", async () => {
+describe("Stream", () => {
   test("Stream Creation", async () => {
     const testCreateItem = {
       updateItem: {
@@ -65,7 +65,7 @@ describe("Stream", async () => {
         evt.event.updateItem,
         schema.UpdateItem.create(testCreateItem.updateItem),
       );
-      expect(evt.signer).toEqual(account.address);
+      expect(await evt.signer).toEqual(account.address);
       break;
     }
 


### PR DESCRIPTION
Made the `recoverMessageAddress` function synchronous after the [mentioned issue.](https://github.com/masslbs/Tennessine/issues/53).

Also update testcase which is use this functionality and failed after the `pull` method update.