### PR TITLE
Bubble errors back to stateManager operations

### DIFF
--- a/packages/client/mod.ts
+++ b/packages/client/mod.ts
@@ -60,7 +60,7 @@ export type Patch =
     }
   );
 
-// TODO: maybe there is a better type definitoin for resolve and reject somewhere
+// TODO: maybe there is a better type definition for resolve and reject somewhere
 export type SendingPatchSet = {
   patches: Patch[];
   resolve?: () => void;
@@ -348,7 +348,7 @@ export class RelayClient {
           }
           const writeError = new ClientWriteError(error, signedPatchSet);
           reject?.(writeError);
-          // throw writeError;
+          throw writeError;
           // TODO: abort stream? if not, swallow the error..?
         }
       },

--- a/packages/client/mod.ts
+++ b/packages/client/mod.ts
@@ -341,15 +341,14 @@ export class RelayClient {
         try {
           const result = await this.encodeAndSend(envelope);
           resolve?.(); // could return response but what for..?
-          return result;
+          return result; // where does this result go..?
         } catch (error) {
           if (!(error instanceof Error)) {
             throw new Error(`unknown error: ${error}`);
           }
           const writeError = new ClientWriteError(error, signedPatchSet);
           reject?.(writeError);
-          throw writeError;
-          // TODO: abort stream? if not, swallow the error..?
+          console.error(writeError);
         }
       },
     });

--- a/packages/client/mod.ts
+++ b/packages/client/mod.ts
@@ -343,12 +343,13 @@ export class RelayClient {
           resolve?.(); // could return response but what for..?
           return result; // where does this result go..?
         } catch (error) {
-          if (!(error instanceof Error)) {
-            throw new Error(`unknown error: ${error}`);
+          if (error instanceof RelayResponseError) {
+            const writeError = new ClientWriteError(error, signedPatchSet);
+            reject?.(writeError);
+            console.error(writeError);
+            return;
           }
-          const writeError = new ClientWriteError(error, signedPatchSet);
-          reject?.(writeError);
-          console.error(writeError);
+          throw new Error(`unknown relay client error: ${error}`);
         }
       },
     });

--- a/packages/stateManager/mod.ts
+++ b/packages/stateManager/mod.ts
@@ -230,14 +230,14 @@ export default class StateManager {
 
   async increment(path: codec.Path, value: codec.CodecValue) {
     const state = await this.#open();
-    this.#sendPatch(state, { Op: "increment", Path: path, Value: value });
+    await this.#sendPatch(state, { Op: "increment", Path: path, Value: value });
     state.root = await this.graph.set(state.root, path, value);
     this.events.emit(state.root);
   }
 
   async decrement(path: codec.Path, value: codec.CodecValue) {
     const state = await this.#open();
-    this.#sendPatch(state, { Op: "decrement", Path: path, Value: value });
+    await this.#sendPatch(state, { Op: "decrement", Path: path, Value: value });
     state.root = await this.graph.set(state.root, path, value);
     this.events.emit(state.root);
   }
@@ -250,7 +250,7 @@ export default class StateManager {
       return value;
     });
     this.events.emit(state.root);
-    return this.#sendPatch(
+    await this.#sendPatch(
       state,
       { Op: op!, Path: path, Value: value },
     );

--- a/packages/stateManager/mod_test.ts
+++ b/packages/stateManager/mod_test.ts
@@ -83,7 +83,7 @@ Deno.test("Database Testings", async (t) => {
       resolve(manifestPatch);
     }, ["Manifest"]);
 
-    const connection = await sm.addConnection(relayClient);
+    await sm.addConnection(relayClient);
     // wait for manifest to be received
     await promise;
     const testAddr = Uint8Array.from([
@@ -125,21 +125,6 @@ Deno.test("Database Testings", async (t) => {
         ["ChainID", 1337],
       ]),
     );
-
-    // would be nice to put this in a new step
-    const badValue = "Truth gains more even by the errors";
-    return new Promise<void>((resolve) => {
-      connection.ours.catch((error) => {
-        console.log(error);
-        assertInstanceOf(error, ClientWriteError);
-        assertEquals(error.patchSet.Patches[0].get("Value"), badValue);
-        resolve();
-      });
-      sm.set(
-        ["Manifest", "PricingCurrency"],
-        badValue,
-      );
-    });
   });
 
   await t.step(
@@ -156,5 +141,16 @@ Deno.test("Database Testings", async (t) => {
       assertEquals(called, true);
     },
   );
+  await t.step("Make sure we can do more then one bad write", async () => {
+    let called = false;
+    try {
+      await sm.set(["Trash"], "Another Bad Value");
+    } catch (e) {
+      console.log(e);
+      assertInstanceOf(e, ClientWriteError);
+      called = true;
+    }
+    assertEquals(called, true);
+  });
   await relayClient.disconnect();
 });


### PR DESCRIPTION
So this was a bit weird.

Afaict stream processing stops if you throw from inside the write function. So if we want to support more then one error happening, we can't use the .catch() style handling.

I therefore ended up removing the old test and am now adding a check if it's a response error, and throw other errors. (so that disconnect for ex. actually defuncts the active stream)