### PR TITLE
Fix regions setup

### DIFF
--- a/packages/frontend/src/components/cart/Checkout_test.tsx
+++ b/packages/frontend/src/components/cart/Checkout_test.tsx
@@ -56,7 +56,6 @@ Deno.test("Check that we can render the checkout screen", {
 
   // TODO: allow for setting the whole accepted currencies map at once
   // await merchantStateManager.set(["Manifest", "AcceptedCurrencies", testCurrency.ChainID, testCurrency.Address],
-  //   // @ts-ignore TODO: add BaseClass to CodecValue
   //   new Map<number, Map<string, boolean>>([
   //     [testCurrency.ChainID, new Map([[testCurrency.Address, true]])],
   //   ])
@@ -82,14 +81,13 @@ Deno.test("Check that we can render the checkout screen", {
     new Map([
       [
         "default",
-        new ShippingRegion("nowhere"),
+        new ShippingRegion(""),
       ],
     ]),
   );
   await merchantStateManager.set(["Manifest"], currentManifest);
 
   // await merchantStateManager.set(["Manifest", "PricingCurrency"],
-  //   // @ts-ignore TODO: add BaseClass to CodecValue
   //   testCurrency
   // );
 
@@ -170,7 +168,7 @@ Deno.test("Check that we can render the checkout screen", {
     "123 Main St",
     "Anytown",
     "12345",
-    "nowhere",
+    "US",
     "john.doe@example.com",
     undefined, // Address 2 not used yet
     "+1234567890",

--- a/packages/frontend/src/components/merchants/create-shop/CreateShop.tsx
+++ b/packages/frontend/src/components/merchants/create-shop/CreateShop.tsx
@@ -264,7 +264,10 @@ export default function () {
         );
       });
       shopManifest.ShopID = shopId;
-      if (shopManifest.ShippingRegions.size === 0) {
+      if (
+        !shopManifest.ShippingRegions ||
+        shopManifest.ShippingRegions.size === 0
+      ) {
         shopManifest.ShippingRegions = new ShippingRegionsMap(
           new Map([
             [

--- a/packages/frontend/src/components/merchants/create-shop/CreateShop.tsx
+++ b/packages/frontend/src/components/merchants/create-shop/CreateShop.tsx
@@ -15,7 +15,11 @@ import {
   mintShop,
   setTokenURI,
 } from "@massmarket/contracts";
-import { Manifest } from "@massmarket/schema";
+import {
+  Manifest,
+  ShippingRegion,
+  ShippingRegionsMap,
+} from "@massmarket/schema";
 import { getWindowLocation, logger, random256BigInt } from "@massmarket/utils";
 import { abi, permissions } from "@massmarket/contracts";
 
@@ -260,6 +264,16 @@ export default function () {
         );
       });
       shopManifest.ShopID = shopId;
+      if (shopManifest.ShippingRegions.size === 0) {
+        shopManifest.ShippingRegions = new ShippingRegionsMap(
+          new Map([
+            [
+              "default",
+              new ShippingRegion(""),
+            ],
+          ]),
+        );
+      }
 
       await stateManager.set(
         ["Manifest"],

--- a/packages/schema/standin_manifest.ts
+++ b/packages/schema/standin_manifest.ts
@@ -114,6 +114,10 @@ export class ShippingRegionsMap {
     }
     return map;
   }
+
+  public get size() {
+    return this.data.size;
+  }
 }
 
 export class PayeeMap {


### PR DESCRIPTION
We don't actually load the manifest the relay creates just yet. So `updateManifest()` actually overwrote the default region the relay set up before.

