### PR TITLE
Update cart quantity + fix pointer hover on top-left logo

### DIFF
--- a/packages/frontend/src/components/ListingDetail.tsx
+++ b/packages/frontend/src/components/ListingDetail.tsx
@@ -20,7 +20,7 @@ import SuccessToast from "./common/SuccessToast.tsx";
 import { useCurrentOrder } from "../hooks/useCurrentOrder.ts";
 
 const namespace = "frontend:listing-detail";
-const describe = (subNamespace) =>
+const describe = (subNamespace: string) =>
   logger(`${namespace}:${subNamespace}`, "warn");
 const warn = logger(namespace, "warn");
 const errlog = logger(namespace, "error");

--- a/packages/frontend/src/components/ListingDetail.tsx
+++ b/packages/frontend/src/components/ListingDetail.tsx
@@ -20,8 +20,7 @@ import SuccessToast from "./common/SuccessToast.tsx";
 import { useCurrentOrder } from "../hooks/useCurrentOrder.ts";
 
 const namespace = "frontend:listing-detail";
-const describe = (subNamespace: string) =>
-  logger(`${namespace}:${subNamespace}`, "warn");
+const debug = logger(namespace);
 const warn = logger(namespace, "warn");
 const errlog = logger(namespace, "error");
 
@@ -71,12 +70,11 @@ export default function ListingDetail() {
   }
 
   function handlePurchaseQty(e: ChangeEvent<HTMLInputElement>) {
-    const newValue = Number(e.target.value.replace(/^0+/, ""));
+    const newValue = parseInt(e.target.value);
     setQuantity(newValue);
   }
 
   async function changeItems() {
-    const say = describe("changeItems()");
     if (!stateManager) {
       warn("stateManager is undefined");
       return;
@@ -111,7 +109,7 @@ export default function ListingDetail() {
           if (item.ListingID === itemId) {
             // this should never happen?
             if (cartItemQuantity !== 0) {
-              say(
+              debug(
                 "cart item quantity for the same item should not be changed more than at most once",
               );
             }

--- a/packages/frontend/src/components/ListingDetail.tsx
+++ b/packages/frontend/src/components/ListingDetail.tsx
@@ -20,6 +20,8 @@ import SuccessToast from "./common/SuccessToast.tsx";
 import { useCurrentOrder } from "../hooks/useCurrentOrder.ts";
 
 const namespace = "frontend:listing-detail";
+const describe = (subNamespace) =>
+  logger(`${namespace}:${subNamespace}`, "warn");
 const warn = logger(namespace, "warn");
 const errlog = logger(namespace, "error");
 
@@ -33,7 +35,7 @@ export default function ListingDetail() {
   const itemId = search.itemId as ListingId;
   const [listing, setListing] = useState<Listing>(new Listing());
   const [tokenIcon, setIcon] = useState("/icons/usdc-coin.png");
-  const [quantity, setQuantity] = useState<string>("");
+  const [quantity, setQuantity] = useState<number>(1);
   const [errorMsg, setErrorMsg] = useState<null | string>(null);
   const [successMsg, setMsg] = useState<string | null>(null);
   const [displayedImg, setDisplayedImg] = useState<string | null>(null);
@@ -69,11 +71,12 @@ export default function ListingDetail() {
   }
 
   function handlePurchaseQty(e: ChangeEvent<HTMLInputElement>) {
-    const newValue = e.target.value.replace(/^0+/, "");
+    const newValue = Number(e.target.value.replace(/^0+/, ""));
     setQuantity(newValue);
   }
 
   async function changeItems() {
+    const say = describe("changeItems()");
     if (!stateManager) {
       warn("stateManager is undefined");
       return;
@@ -81,7 +84,7 @@ export default function ListingDetail() {
     try {
       let orderId = currentOrder?.ID;
       if (!orderId) {
-        await createOrder(itemId, Number(quantity));
+        await createOrder(itemId, quantity);
         setMsg("Item added to cart");
         return;
       }
@@ -101,12 +104,25 @@ export default function ListingDetail() {
         throw new Error(`Order ${orderId} not found`);
       }
       const order: Order = Order.fromCBOR(o);
+      let cartItemQuantity = 0;
       // If item already exists in the items array, filter it out so we can replace it with the new quantity
       const updatedOrderItems = (order.Items ?? []).filter(
-        (item: OrderedItem) => item.ListingID !== itemId,
+        (item: OrderedItem) => {
+          if (item.ListingID === itemId) {
+            // this should never happen?
+            if (cartItemQuantity !== 0) {
+              say(
+                "cart item quantity for the same item should not be changed more than at most once",
+              );
+            }
+            cartItemQuantity = item.Quantity;
+          }
+          return item.ListingID !== itemId;
+        },
       );
+      // note: cartItemQuantity is 0 if this is the first time we add the item to our cart, and adding with 0 is fine :)
       updatedOrderItems.push(
-        new OrderedItem(itemId, Number(quantity)),
+        new OrderedItem(itemId, cartItemQuantity + quantity),
       );
 
       await stateManager.set(
@@ -114,7 +130,7 @@ export default function ListingDetail() {
         // TODO: this is a bit of a hack, since StateManager doesnt handle BaseClass[]
         updatedOrderItems.map((item: OrderedItem) => item.asCBORMap()),
       );
-      setQuantity("");
+      setQuantity(1);
       setMsg("Cart updated");
     } catch (error) {
       errlog(`Error: changeItems ${error}`);
@@ -228,7 +244,7 @@ export default function ListingDetail() {
                   value={quantity}
                   data-testid="purchaseQty"
                   type="number"
-                  min="0"
+                  min="1"
                   step="1"
                   onChange={(e) => handlePurchaseQty(e)}
                 />

--- a/packages/frontend/src/components/Navigation.tsx
+++ b/packages/frontend/src/components/Navigation.tsx
@@ -203,7 +203,7 @@ function Navigation() {
     >
       <section className="w-full p-2 text-base flex justify-between bg-white md:px-8">
         <div
-          className="flex gap-2"
+          className="flex gap-2 cursor-pointer"
           onClick={() =>
             navigate({
               to: "/listings",


### PR DESCRIPTION
The top left element is used as a component to lead a user to the back
to /listings when clicked. We now put cursor: pointer on it, so that a
cursor turns into a pointing hand to signify "hey i am clickable!".

---

This commit changes quantity in ListingDetail.tsx to be of type number
rather than string. We also set defaults of values to be 1 rather than
empty string or 0, as it is a better UX for customers to be able to click
"Add to basket" rather than having to increment first and then click
Add.

The major change concerns what to do when "Add to basket" is clicked for
an item that is already in the cart. Previously the item quantity was fully
replaced with the newly added quantity. A more intuitive behaviour is to
instead add the two quantities such that:

cart(item).quantity = cart(item).quantity + newQuantity
