### PR TITLE
fix(nav/cart): basket icon is correctly reset after successful checkout; entire menu row is now clickable

### DIFF
--- a/packages/frontend/src/components/Navigation.tsx
+++ b/packages/frontend/src/components/Navigation.tsx
@@ -175,31 +175,31 @@ function Navigation() {
           key={i}
           onClick={() => setMenuOpen(false)}
         >
-          <div className="flex gap-3 items-center">
-            <img
-              src={`/icons/${opt.img}`}
-              width={20}
-              height={20}
-              alt="menu-item"
-              className="w-5 h-5"
-            />
-            <Link
-              to={opt.href!}
-              key={opt.title}
-              search={(prev: Record<string, string>) => ({
-                shopId: prev.shopId,
-              })}
-            >
+          <Link
+            to={opt.href!}
+            key={opt.title}
+            search={(prev: Record<string, string>) => ({
+              shopId: prev.shopId,
+            })}
+          >
+            <div className="flex gap-3 items-center">
+              <img
+                src={`/icons/${opt.img}`}
+                width={20}
+                height={20}
+                alt="menu-item"
+                className="w-5 h-5"
+              />
               <h2 className="font-normal text-black">{opt.title}</h2>
-            </Link>
-            <img
-              src="/icons/chevron-right.svg"
-              width={12}
-              height={12}
-              alt="chevron-right"
-              className="ml-auto w-3 h-3"
-            />
-          </div>
+              <img
+                src="/icons/chevron-right.svg"
+                width={12}
+                height={12}
+                alt="chevron-right"
+                className="ml-auto w-3 h-3"
+              />
+            </div>
+          </Link>
         </div>
       );
     });


### PR DESCRIPTION
In the hook `useCurrentOrder`, we "reset" `currentOrder` for the following states:
* OrderState.Canceled
* OrderState.Paid.

This resetting is done by setting currentOrder to null, causing this bug.

The bug raises the question of using a sentinel value, instead of null, to represent reset orders where we would do e.g.

currentOrder = SENTINEL_ORDER

where SENTINEL_ORDER is a fake order set as a constant and checked against in addition to simple null checks.

---
Also:

[fix(nav/menu): make entire menu row clickable, not just text](https://github.com/masslbs/Tennessine/pull/346/commits/1bfa626db307240a421139057ea2706fd078a633)