### PR TITLE
fix(modal): click outside menu consistently closes modal

### DIFF
--- a/packages/frontend/src/components/Navigation.tsx
+++ b/packages/frontend/src/components/Navigation.tsx
@@ -305,7 +305,7 @@ function Navigation() {
         />
       )}
       <section className="md:flex md:justify-center">
-        <section className="md:w-[800px] md:flex md:justify-end absolute">
+        <section className="md:ml-[calc(800px-13rem)] md:flex md:justify-end absolute">
           {menuOpen
             ? (
               <section>


### PR DESCRIPTION
The issue was that width was being used to adjust the positioning for the cart dropdown. This caused the cart dropdown to billow out invisibly and absorb clicks that were thought to be outside of the menu and thus going counter to expectations that the modal would be closed.

Ideally, the dropdown would be positioned in the component hierarchy such that it could simply be aligned to the end and we don't need any of these margin-style adjustments, but this was a less invasive fix :)

closes #375