### PR TITLE
fix(merchant/listings): simplify merchant overview + fix product image in edit-listing

### DIFF
--- a/packages/frontend/src/components/ListingDetail_test.tsx
+++ b/packages/frontend/src/components/ListingDetail_test.tsx
@@ -1,4 +1,5 @@
 import "../happyDomSetup.ts";
+import { formatUnits } from "viem";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { expect } from "@std/expect";
 import { userEvent } from "@testing-library/user-event";
@@ -10,7 +11,6 @@ import type { CodecKey, CodecValue } from "@massmarket/utils/codec";
 
 import ListingDetail from "./ListingDetail.tsx";
 import { createRouterWrapper, testClient } from "../testutils/mod.tsx";
-import { formatUnits } from "viem";
 import { OrderState } from "../types.ts";
 
 Deno.test("Check that we can render the listing details screen", {
@@ -159,6 +159,8 @@ Deno.test("Check that we can render the listing details screen", {
       initialQty + qtyIncreasedBy + qtyIncreasedBy2,
     );
   }, { timeout: 10000 });
+
+  await stateManager.close();
 
   unmount();
 

--- a/packages/frontend/src/components/merchants/listings/EditListing.tsx
+++ b/packages/frontend/src/components/merchants/listings/EditListing.tsx
@@ -329,6 +329,7 @@ export default function EditProduct() {
                         height={95}
                         data-testid="uploaded-product-image"
                         style={{
+                          objectFit: "cover",
                           maxHeight: "95px",
                           maxWidth: "105px",
                           minHeight: "95px",

--- a/packages/frontend/src/components/merchants/listings/MerchantViewListings.tsx
+++ b/packages/frontend/src/components/merchants/listings/MerchantViewListings.tsx
@@ -82,11 +82,10 @@ export default function MerchantViewProducts({
               />
             </div>
             <div className="flex justify-between mt-2 border-b border-gray-300 w-full pb-2">
-              <p>Stock Level</p>
+              <p>Stock #</p>
               <p>{quantity}</p>
             </div>
             <div className="flex justify-between pt-2 mt-auto">
-              <p>Price</p>
               <div className="flex gap-1 items-center">
                 <img
                   src={baseToken?.symbol === "ETH"

--- a/packages/merkle-dag-builder/mod_test.ts
+++ b/packages/merkle-dag-builder/mod_test.ts
@@ -1,7 +1,7 @@
 import { assert, assertEquals, assertRejects } from "@std/assert";
 import { MemStore as Store } from "@massmarket/store/mem";
 import type { CodecValue } from "@massmarket/utils/codec";
-import { DAG, type RootValue } from "./mod.ts";
+import { DAG, type NodeValue, type RootValue } from "./mod.ts";
 import { assertNotEquals } from "@std/assert/not-equals";
 import { set } from "@massmarket/utils";
 
@@ -19,10 +19,10 @@ const store = new Store();
 
 Deno.test("basic set and get ", async (t) => {
   await t.step("Map with string keys", async () => {
-    const root: RootValue = new Map();
     const graph = new DAG(
       store,
     );
+    const root: RootValue = graph.createNewRoot();
     const newRoot = await graph.set(root, ["c"], "cat");
     assertNotEquals(root, newRoot);
     const val = await graph.get(newRoot, ["c"]);
@@ -30,10 +30,10 @@ Deno.test("basic set and get ", async (t) => {
   });
 
   await t.step("Map with Uint8Array keys", async () => {
-    let root: RootValue = new Map();
     const graph = new DAG(
       store,
     );
+    let root: RootValue = graph.createNewRoot();
     const addresses = new Map([
       [new Uint8Array([1, 2, 3]), "address1"],
       [new Uint8Array([4, 5, 6]), "address2"],
@@ -48,13 +48,16 @@ Deno.test("basic set and get ", async (t) => {
   });
 
   await t.step("A path that does not exist (pathing into a map)", async () => {
-    const root: RootValue = new Map();
     const graph = new DAG(
       store,
     );
+    const root: RootValue = graph.createNewRoot();
     const val = await graph.get(root, ["d"]);
     assertEquals(val, undefined);
-    assertRejects(() => graph.get(new Uint8Array(32), ["c"]), "invalid root");
+    assertRejects(
+      () => graph.get(new Uint8Array(32), ["c"]),
+      "invalid root",
+    );
     assertRejects(
       () => graph.set(root, ["c", "d", "c"], "catz"),
       "path does not exist",
@@ -65,10 +68,10 @@ Deno.test("basic set and get ", async (t) => {
   await t.step(
     "A path that cannot not exist (trying to path through a string)",
     async () => {
-      const root: RootValue = new Map();
       const graph = new DAG(
         store,
       );
+      const root: RootValue = graph.createNewRoot();
       const r = await graph.get(root, ["c", "d"]);
       assertEquals(r, undefined);
     },
@@ -81,15 +84,17 @@ Deno.test("upsert", async (t) => {
       store,
     );
 
-    const addresses: CodecValue | Promise<CodecValue> | undefined = new Map([
-      [new Uint8Array([1, 2, 3]), "address1"],
-      [new Uint8Array([4, 5, 6]), "address2"],
-    ]);
+    const addresses = graph.createNewRoot(
+      new Map([
+        [new Uint8Array([1, 2, 3]), "address1"],
+        [new Uint8Array([4, 5, 6]), "address2"],
+      ]),
+    ) as NodeValue;
     const newAddresses = graph.set(
       addresses,
       ["addresses"],
       (oldAddress, path) => {
-        assertEquals(oldAddress, addresses);
+        assertEquals(oldAddress, addresses[0]);
         set(oldAddress, path, "cat");
       },
     );
@@ -100,12 +105,12 @@ Deno.test("upsert", async (t) => {
 
 Deno.test("should merklize", async (t) => {
   let merkleRoot;
-  let root: RootValue = new Map();
+  let root: RootValue;
   await t.step("should create a merkle root", async () => {
     const graph = new DAG(
       store,
     );
-
+    root = graph.createNewRoot();
     merkleRoot = await graph.merklelize(root);
     assert(merkleRoot instanceof Uint8Array);
   });
@@ -127,7 +132,7 @@ Deno.test.ignore(
   async (t) => {
     const store = new Store();
     const dag = new DAG(store);
-    const root: RootValue = new Map();
+    const root = dag.createNewRoot();
 
     await t.step("should handle many sequential sets and gets", async () => {
       const iterations = 1000;
@@ -182,7 +187,7 @@ Deno.test.ignore(
 
     await t.step("should handle parallel sets and gets", async () => {
       const iterations = 100;
-      let currentRoot: RootValue = new Map();
+      let currentRoot = dag.createNewRoot();
 
       // Parallel sets
       Array(iterations).fill(0).map((_, i) => {
@@ -202,7 +207,7 @@ Deno.test.ignore(
     });
 
     await t.step("should handle large values", async () => {
-      let currentRoot: CodecValue = new Map();
+      let currentRoot = dag.createNewRoot();
       const largeArray = Array(10000).fill(0).map((
         _,
         i,

--- a/packages/merkle-dag-builder/timestampTree.ts
+++ b/packages/merkle-dag-builder/timestampTree.ts
@@ -1,0 +1,35 @@
+import { type codec, get } from "@massmarket/utils";
+import { assertExists } from "@std/assert";
+
+export type TimestampTree = [
+  Map<codec.CodecKey, TimestampTree>,
+  codec.CodecValue,
+];
+
+export function getOrExtend(
+  tree: TimestampTree,
+  step: codec.CodecKey,
+  mutate: boolean,
+) {
+  const next = get(tree[0], step);
+  if (next) {
+    return next;
+  } else {
+    if (mutate) {
+      const newTree: TimestampTree = [new Map(), tree[1]];
+      tree[0].set(step, newTree);
+      return newTree;
+    } else {
+      return tree;
+    }
+  }
+}
+
+// get the timestamp of the current node, or find the timestamp of the node's parent
+export function getTimestamp(
+  tree: TimestampTree,
+): codec.CodecValue {
+  const timestamp = tree[1];
+  assertExists(timestamp, "Timestamp not found");
+  return timestamp;
+}

--- a/packages/stateManager/mod.ts
+++ b/packages/stateManager/mod.ts
@@ -241,7 +241,6 @@ export default class StateManager {
         { Op: op, Path: path, Value: value },
       );
     });
-<<<<<<< HEAD
     try {
       // TODO (@nullradix 2025-04-28) If we revert the state
       // here, we would potentaily be reverting multiple operations
@@ -257,11 +256,6 @@ export default class StateManager {
       state.root = oldStateRoot;
       throw e;
     }
-=======
-    const r = await state.root;
-    this.events.emit(r[0]);
-    return sendpromise!;
->>>>>>> a4cc79d (Timestamp (#395))
   }
 
   get(

--- a/packages/stateManager/mod.ts
+++ b/packages/stateManager/mod.ts
@@ -1,6 +1,10 @@
 import { assert } from "@std/assert";
 
-import { DAG, type RootValue } from "@massmarket/merkle-dag-builder";
+import {
+  DAG,
+  type NodeValue,
+  type RootValue,
+} from "@massmarket/merkle-dag-builder";
 import type { AbstractStore } from "@massmarket/store";
 import EventTree from "@massmarket/eventTree";
 import type { Patch, PushedPatchSet, RelayClient } from "@massmarket/client";
@@ -25,7 +29,7 @@ interface IStoredState {
 
 export default class StateManager {
   readonly events = new EventTree<codec.CodecValue>(new Map());
-  readonly graph: DAG;
+  readonly graph: DAG<codec.CodecValue>;
   readonly clients: Set<RelayClient> = new Set();
   readonly id: bigint;
   #streamsWriters: Set<WritableStreamDefaultWriter<Patch[]>> = new Set();
@@ -36,12 +40,14 @@ export default class StateManager {
     params: {
       store: AbstractStore;
       id: bigint;
-      defaultState?: RootValue;
+      defaultState?: codec.CodecValue | Hash;
     },
   ) {
     this.id = params.id;
     this.graph = new DAG(params.store);
-    this.#defaultState = params?.defaultState ?? new Map();
+    this.#defaultState = this.graph.createNewRoot(
+      params?.defaultState ?? new Map(),
+    );
   }
 
   get root(): RootValue {
@@ -61,7 +67,8 @@ export default class StateManager {
         // root: v.getDefaults(this.params.schema) as CborValue,
       };
     this.#state = restored;
-    this.events.emit(this.#state.root as HashOrValue);
+    const root = this.#state.root as NodeValue;
+    this.events.emit(root[0]);
   }
 
   async close() {
@@ -74,14 +81,17 @@ export default class StateManager {
     });
     this.clients.clear();
     // wait for root to be resolved
-    state.root = await state.root;
-    return Promise.all([
+    const closingResults = await Promise.all([
       ...closingClients,
-      this.graph.store.objStore.set(
-        this.id,
-        new Map(Object.entries(state)),
-      ),
+      state.root,
     ]);
+
+    state.root = closingResults.pop() as RootValue;
+
+    return this.graph.store.objStore.set(
+      this.id,
+      new Map(Object.entries(state)),
+    );
   }
 
   createWriteStream(remoteId: string, subscriptionPath: codec.Path) {
@@ -100,27 +110,26 @@ export default class StateManager {
         //   throw new Error("Invalid keycard");
         for (const patch of patchSet.patches) {
           // TODO validate the Operation's value if any
-          // console.log("Applying patch:", patch);
           if (patch.Op === "add") {
-            state.root = await this.graph.add(
+            state.root = this.graph.add(
               state.root,
               patch.Path,
               patch.Value,
             );
           } else if (patch.Op === "replace") {
-            state.root = await this.graph.set(
+            state.root = this.graph.set(
               state.root,
               patch.Path,
               patch.Value,
             );
           } else if (patch.Op === "append") {
-            state.root = await this.graph.append(
+            state.root = this.graph.append(
               state.root,
               patch.Path,
               patch.Value,
             );
           } else if (patch.Op === "remove") {
-            state.root = await this.graph.remove(
+            state.root = this.graph.remove(
               state.root,
               patch.Path,
             );
@@ -148,7 +157,7 @@ export default class StateManager {
         );
         // we want to wait to resolve the promise before emitting the new state
         state.root = await state.root;
-        this.events.emit(state.root);
+        this.events.emit(state.root[0]);
         // TODO: check stateroot
         // TODO: we are saving the patches here
         // incase we want to replay the log, but we have no way to get them out
@@ -232,6 +241,7 @@ export default class StateManager {
         { Op: op, Path: path, Value: value },
       );
     });
+<<<<<<< HEAD
     try {
       // TODO (@nullradix 2025-04-28) If we revert the state
       // here, we would potentaily be reverting multiple operations
@@ -247,6 +257,11 @@ export default class StateManager {
       state.root = oldStateRoot;
       throw e;
     }
+=======
+    const r = await state.root;
+    this.events.emit(r[0]);
+    return sendpromise!;
+>>>>>>> a4cc79d (Timestamp (#395))
   }
 
   get(

--- a/packages/stateManager/patching_test.ts
+++ b/packages/stateManager/patching_test.ts
@@ -4,6 +4,7 @@ import type { PushedPatchSet } from "@massmarket/client";
 import type { CodecValue, Path } from "@massmarket/utils/codec";
 import { extractEntriesFromHAMT, fetchAndDecode } from "@massmarket/utils";
 import { assertEquals } from "@std/assert/equals";
+import type { NodeValue } from "@massmarket/merkle-dag-builder";
 
 Deno.test("Database Testings", async (t) => {
   const testFiles = [
@@ -70,7 +71,8 @@ Deno.test("Database Testings", async (t) => {
             if (skippedTests.has(test.description)) {
               console.log("Skipping state check!!!!!!!");
             } else {
-              assertEquals(sm.root, after);
+              const root = sm.root as NodeValue;
+              assertEquals(root[0], after);
             }
             await sm.close();
           });


### PR DESCRIPTION
This commit simplifies the merchant listings overview, preserving information while also making it look less dense and cramped on mid-to-smaller viewports.

Before:

![2025-04-25-145831_1023x508_scrot](https://github.com/user-attachments/assets/b9f8ee88-a0fb-43b6-bfc9-1dc6f7346440)


After:

![2025-04-25-145634_1046x506_scrot](https://github.com/user-attachments/assets/33ad2131-5b76-4b21-b743-7467b0a3455f)
