### PR TITLE
debugging event ordering

### DIFF
--- a/packages/client/mod.ts
+++ b/packages/client/mod.ts
@@ -334,8 +334,9 @@ export class RelayClient {
         id = payload!;
       },
       cancel: async (reason) => {
-        this.#subscriptions.delete(id.toString());
+        console.log("cancelling subscription:", reason);
         await this.cancelSubscriptionRequest(id, reason);
+        this.#subscriptions.delete(id.toString());
       },
     });
   }

--- a/packages/client/mod.ts
+++ b/packages/client/mod.ts
@@ -69,6 +69,7 @@ export type PushedPatchSet = {
   patches: Patch[];
   header: CodecValue;
   sequence: number;
+  done: Promise<schema.Envelope>;
 };
 
 export type SignedPatchSet = {
@@ -264,17 +265,15 @@ export class RelayClient {
                 header,
                 signer,
                 sequence,
+                done: this.encodeAndSend({
+                  requestId: envelope.requestId,
+                  response: {},
+                }),
               });
             }
           } catch (e) {
             controller.error(e);
           }
-          // TODO: properly handle backpressure
-          // we should implement `pull` for the read stream, in the pull we should request the next chunk
-          this.encodeAndSendNoWait({
-            requestId: envelope.requestId,
-            response: {},
-          });
         }
         break;
       default:

--- a/packages/frontend/.env.production
+++ b/packages/frontend/.env.production
@@ -1,5 +1,5 @@
-VITE_RELAY_ENDPOINT=wss://relay-staging.mass.market/v4
-VITE_RELAY_TOKEN_ID=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+VITE_RELAY_ENDPOINT=wss://relay-sepolia.mass.market/v4
+VITE_RELAY_TOKEN_ID=0x0
 VITE_CHAIN_NAME=sepolia
 VITE_SENTRY_DSN=https://0bb6acf08a2a48a1ade7ed7d100d1345@glitchtip.mass.market/2
 VITE_ETH_RPC_URL=wss://ethereum-sepolia-rpc.publicnode.com

--- a/packages/frontend/src/hooks/useStateManager.ts
+++ b/packages/frontend/src/hooks/useStateManager.ts
@@ -66,7 +66,7 @@ export function useStateManager() {
     }
     const db = stateManager ??
       await createStateManager(shopId, keycard.privateKey);
-
+    globalThis.stateManager = db;
     // Skip this logic if /create-shop or /merchant-connect, since we need to enroll merchant keycard before we call addConnection in those cases.
     if (!isMerchantPath && relayClient) {
       if (keycard?.role === KeycardRole.NEW_GUEST) {

--- a/packages/frontend/src/hooks/useStateManager.ts
+++ b/packages/frontend/src/hooks/useStateManager.ts
@@ -66,6 +66,7 @@ export function useStateManager() {
     }
     const db = stateManager ??
       await createStateManager(shopId, keycard.privateKey);
+    // @ts-ignore TODO: remove me - just for debugging
     globalThis.stateManager = db;
     // Skip this logic if /create-shop or /merchant-connect, since we need to enroll merchant keycard before we call addConnection in those cases.
     if (!isMerchantPath && relayClient) {

--- a/packages/stateManager/mod.ts
+++ b/packages/stateManager/mod.ts
@@ -142,8 +142,6 @@ export default class StateManager {
           }
         }
 
-        await patchSet.done();
-
         state.subscriptionSequenceNumber = patchSet.sequence;
         // we want to wait to resolve the promise before emitting the new state
         state.root = await state.root;
@@ -155,6 +153,9 @@ export default class StateManager {
         //   [patchSet.signer, "patches"],
         //   patchSet.patches,
         // );
+
+        // backpressure, request next chunk
+        await patchSet.done;
       },
     });
   }

--- a/packages/stateManager/mod.ts
+++ b/packages/stateManager/mod.ts
@@ -89,6 +89,7 @@ export default class StateManager {
     assert(state, "open not finished");
     return new WritableStream<PushedPatchSet>({
       write: async (patchSet) => {
+        console.log("writing seq:", patchSet.sequence);
         // TODO: validate the Operation's schema
         // const _validityRange = await this.graph.get(state.root, [
         //   "Account",

--- a/packages/stateManager/mod.ts
+++ b/packages/stateManager/mod.ts
@@ -142,6 +142,8 @@ export default class StateManager {
           }
         }
 
+        await patchSet.done();
+
         state.subscriptionSequenceNumber = patchSet.sequence;
         // we want to wait to resolve the promise before emitting the new state
         state.root = await state.root;


### PR DESCRIPTION
Here are two syncs from 0. In the broken one one set of patches is processed before the other..

This attempts to rectify the backpressure implementation, so that we don't request more pushes before we actually processed them but i can't get the `done` to work for some reason...

my hunch is `envelope.requestId` changed by the time it fires..? i'm still baffled by when javascript types are by reference and when they copy properly...