### PR TITLE
Fix hamt vector keys

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -11,6 +11,7 @@
     "jsr:@std/assert@^1.0.12": "1.0.12",
     "jsr:@std/assert@^1.0.13": "1.0.13",
     "jsr:@std/data-structures@^1.0.6": "1.0.6",
+    "jsr:@std/encoding@*": "1.0.8",
     "jsr:@std/expect@^1.0.15": "1.0.15",
     "jsr:@std/fs@^1.0.16": "1.0.16",
     "jsr:@std/internal@^1.0.6": "1.0.6",
@@ -101,6 +102,9 @@
     },
     "@std/data-structures@1.0.6": {
       "integrity": "76a7fd8080c66604c0496220a791860492ab21a04a63a969c0b9a0609bbbb760"
+    },
+    "@std/encoding@1.0.8": {
+      "integrity": "a6c8f3f933ab1bed66244f435d1dc0fd23a888e07195532122ddc3d5f8f0e6b4"
     },
     "@std/expect@1.0.15": {
       "integrity": "eca360007b5a7f13dbfa1294224baee7fb98dcd460d8461fe64eeae302902945",
@@ -4684,7 +4688,6 @@
           "npm:rolldown-vite@^6.3.6",
           "npm:tailwindcss@^4.1.4",
           "npm:viem@^2.28.1",
-
           "npm:wagmi@^2.15.1",
           "npm:web-streams-polyfill@^4.1.0"
         ]
@@ -4731,6 +4734,7 @@
       "packages/utils": {
         "dependencies": [
           "jsr:@std/assert@^1.0.13",
+          "jsr:@std/expect@^1.0.15",
           "npm:@sentry/browser@9.15.0",
           "npm:cbor-x@^1.6.0",
           "npm:viem@^2.28.1"

--- a/packages/utils/deno.json
+++ b/packages/utils/deno.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.13",
+    "@std/expect": "jsr:@std/expect@^1.0.15",
     "viem": "npm:viem@^2.28.1",
     "@sentry/browser": "npm:@sentry/browser@9.15.0",
     "cbor-x": "npm:cbor-x@^1.6.0"

--- a/packages/utils/mod.ts
+++ b/packages/utils/mod.ts
@@ -139,7 +139,7 @@ export function extractEntriesFromHAMT(
   }
 
   const entries = hamtNode[1];
-  const result = new Map<number, CodecValue>();
+  const result = new Map<number | Uint8Array, CodecValue>();
 
   if (Array.isArray(entries)) {
     for (const entry of entries) {
@@ -162,14 +162,18 @@ export function extractEntriesFromHAMT(
           // This is a leaf node
           const key = entry[0];
           const value = entry[1];
-          // Convert key (Uint8Array) to number (8-byte big endian)
-          const keyNum = new DataView(
-            key.buffer,
-            key.byteOffset,
-            key.byteLength,
-          )
-            .getBigUint64(0, false);
-          result.set(Number(keyNum), value);
+          if (key.length === 8) {
+            // Convert key (Uint8Array) to number (8-byte big endian)
+            const keyNum = new DataView(
+              key.buffer,
+              key.byteOffset,
+              key.byteLength,
+            )
+              .getBigUint64(0, false);
+            result.set(Number(keyNum), value);
+          } else {
+            result.set(key, value);
+          }
         }
       }
     }

--- a/packages/utils/mod_test.ts
+++ b/packages/utils/mod_test.ts
@@ -1,0 +1,144 @@
+import { expect } from "@std/expect";
+import { extractEntriesFromHAMT, fetchAndDecode } from "./mod.ts";
+import type { CodecValue } from "./codec.ts";
+
+let snapshots: Map<string, Map<string, CodecValue>>[];
+Deno.test("fetchAndDecode with ShopOkay vector", async () => {
+  const testVector = await fetchAndDecode("ShopOkay");
+  console.log("fetchAndDecode with ShopOkay vector");
+
+  // Verify the returned object is a Map (TestVector)
+  expect(testVector instanceof Map).toBe(true);
+
+  // Verify it contains expected properties
+  expect(testVector.has("Snapshots")).toBe(true);
+
+  // Get the snapshots array
+  snapshots = testVector.get("Snapshots") as Map<
+    string,
+    Map<string, CodecValue>
+  >[];
+  expect(Array.isArray(snapshots)).toBe(true);
+
+  expect(snapshots.length).toBeGreaterThan(0);
+});
+
+Deno.test("hamt extraction gives correct keys (accounts)", () => {
+  const firstSnapshot = snapshots[5]; // test case "add-guest-account"
+  expect(firstSnapshot instanceof Map).toBe(true);
+
+  // Check if we can access "After" -> "Value" -> "Accounts"
+  const after = firstSnapshot.get("After");
+  expect(after instanceof Map).toBe(true);
+
+  if (after) {
+    const value = after.get("Value");
+    expect(value instanceof Map).toBe(true);
+    if (value instanceof Map && value.has("Accounts")) {
+      const accounts = value.get("Accounts");
+      expect(accounts).toBeInstanceOf(Array);
+
+      const accountMap = extractEntriesFromHAMT(accounts);
+      if (accountMap) {
+        expect(accountMap instanceof Map).toBe(true);
+        if (accountMap instanceof Map) {
+          expect(accountMap.size).toBe(2);
+          // Verify all keys in the account map are Uint8Array(20)
+          for (const key of accountMap.keys()) {
+            expect(key instanceof Uint8Array).toBe(true);
+            const keyArr = key as Uint8Array;
+            expect(keyArr.length).toBe(20);
+            // console.log("account key:", printKey(keyArr));
+          }
+        }
+      }
+    }
+  }
+});
+
+Deno.test("hamt extraction gives correct keys (listings)", () => {
+  // Find a snapshot with listings
+  const listingSnapshot = snapshots.filter((snapshot) => {
+    const after = snapshot.get("After");
+    if (after instanceof Map) {
+      const value = after.get("Value");
+      if (value instanceof Map) {
+        const listings = value.get("Listings");
+        return listings !== undefined;
+      }
+    }
+    return false;
+  });
+
+  expect(listingSnapshot.length).toBeGreaterThan(0);
+
+  for (const snapshot of listingSnapshot) {
+    const after = snapshot.get("After");
+    expect(after instanceof Map).toBe(true);
+
+    if (after) {
+      const value = after.get("Value");
+      expect(value instanceof Map).toBe(true);
+
+      if (value instanceof Map && value.has("Listings")) {
+        const listings = value.get("Listings");
+        expect(listings).toBeInstanceOf(Array);
+
+        const listingMap = extractEntriesFromHAMT(listings);
+        expect(listingMap instanceof Map).toBe(true);
+
+        if (listingMap instanceof Map) {
+          // Verify all keys in the listing map are numbers
+          for (const key of listingMap.keys()) {
+            expect(typeof key).toBe("number");
+            // console.log("listing key:", key);
+          }
+        }
+      }
+    }
+  }
+});
+
+Deno.test("hamt extraction gives correct keys (orders)", () => {
+  // Find a snapshot with orders
+  const orderSnapshot = snapshots.filter((snapshot) => {
+    const after = snapshot.get("After");
+    if (after instanceof Map) {
+      const value = after.get("Value");
+      if (value instanceof Map) {
+        const orders = value.get("Orders");
+        return orders !== undefined;
+      }
+    }
+    return false;
+  });
+
+  // If no snapshot has orders, this test is inconclusive but shouldn't fail
+  expect(orderSnapshot.length).toBeGreaterThan(0);
+
+  for (const snapshot of orderSnapshot) {
+    const after = snapshot.get("After");
+    expect(after instanceof Map).toBe(true);
+
+    if (after) {
+      const value = after.get("Value");
+      expect(value instanceof Map).toBe(true);
+
+      if (value instanceof Map && value.has("Orders")) {
+        const orders = value.get("Orders");
+        expect(orders).toBeInstanceOf(Array);
+
+        const orderMap = extractEntriesFromHAMT(orders);
+        expect(orderMap instanceof Map).toBe(true);
+
+        if (orderMap instanceof Map) {
+          // Verify all keys in the order map are numbers
+          for (const key of orderMap.keys()) {
+            expect(typeof key).toBe("number");
+            // console.log("order key:", key);
+          }
+        }
+      }
+    }
+  }
+});


### PR DESCRIPTION
* correct key type for account tries

No changes needed to pass most vector minus a few known issues.

* Notably there is still some difference in the handling of arrays.
* This also surfaces issue #342 (big id numbers). Diabled those for now.