### PR TITLE
wait with processing until previous call is done

### DIFF
--- a/packages/client/mod.ts
+++ b/packages/client/mod.ts
@@ -534,9 +534,15 @@ export class RelayClient {
         },
       );
 
+      let messageDecoding = Promise.resolve();
       this.connection.addEventListener(
         "message",
-        this.#decodeMessage.bind(this),
+        (data) => {
+          // Here we wait to decode the message until the previous message is fully processed
+          messageDecoding = messageDecoding.then(() =>
+            this.#decodeMessage(data)
+          );
+        },
       );
     }
     return new Promise((resolve) => {


### PR DESCRIPTION
until we properly fix #458, we need to be careful to process the patchsets in the right order and that we don't start processing other patches before the previous `#decodeMessage` returned.