### PR TITLE
Revert vite pipeline changes

### DIFF
--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 .vite
 *.local
+cache.json
 
 # Editor directories and files
 .vscode/*

--- a/packages/frontend/deno.json
+++ b/packages/frontend/deno.json
@@ -30,6 +30,7 @@
     "@testing-library/user-event": "npm:@testing-library/user-event@^14.6.1",
     "@testing-library/react-hooks": "npm:@testing-library/react-hooks@^8.0.1",
     "@types/react": "npm:@types/react@^19.1.2",
+    "@vitejs/plugin-react": "npm:@vitejs/plugin-react@^4.4.1",
     "@wagmi/core": "npm:@wagmi/core@^2.17.0",
     "browser-level": "npm:browser-level@^3.0.0",
     "qrcode": "npm:qrcode@^1.5.4",
@@ -37,6 +38,7 @@
     "viem": "npm:viem@^2.28.1",
     "react": "npm:react@^19.1.0",
     "react-dom": "npm:react-dom@^19.1.0",
+    "vite": "npm:vite@^6.3.2",
     "wagmi": "npm:wagmi@^2.15.1",
     "@uidotdev/usehooks": "npm:@uidotdev/usehooks@^2.4.1",
     "web-streams-polyfill": "npm:web-streams-polyfill@^4.1.0"

--- a/packages/frontend/deno.json
+++ b/packages/frontend/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
-    "dev": "deno run -A ./scripts/dev.ts",
-    "build": "deno run -A ./scripts/build.ts",
+    "dev": "deno run -A npm:vite",
+    "build": "deno run -A npm:vite build",
     "serve": "deno run --allow-net --allow-read jsr:@std/http@1/file-server dist/",
     "update-release-info": "deno run -A scripts/write-current-release.ts",
     "generate": "deno run -A scripts/generate-entry-points.ts",
@@ -30,11 +30,9 @@
     "@testing-library/user-event": "npm:@testing-library/user-event@^14.6.1",
     "@testing-library/react-hooks": "npm:@testing-library/react-hooks@^8.0.1",
     "@types/react": "npm:@types/react@^19.1.2",
-    "@vitejs/plugin-react-swc": "npm:@vitejs/plugin-react-swc@^3.9.0",
     "@wagmi/core": "npm:@wagmi/core@^2.17.0",
     "browser-level": "npm:browser-level@^3.0.0",
     "qrcode": "npm:qrcode@^1.5.4",
-    "rolldown-vite": "npm:rolldown-vite@^6.3.6",
     "tailwindcss": "npm:tailwindcss@^4.1.4",
     "viem": "npm:viem@^2.28.1",
     "react": "npm:react@^19.1.0",
@@ -44,6 +42,7 @@
     "web-streams-polyfill": "npm:web-streams-polyfill@^4.1.0"
   },
   "compilerOptions": {
+    "noErrorTruncation": true,
     "lib": ["ESNext", "dom", "dom.iterable", "dom.asynciterable", "deno.ns"],
     "jsx": "react-jsx",
     "jsxImportSource": "react",

--- a/packages/frontend/scripts/build.ts
+++ b/packages/frontend/scripts/build.ts
@@ -1,9 +1,0 @@
-import { build } from "rolldown-vite";
-import config from "./vite.ts";
-
-await build(
-  config({ mode: "production", command: "build" }),
-);
-
-// Vite spawns esbuild which prevents this from exiting automatically
-Deno.exit(0);

--- a/packages/frontend/scripts/dev.ts
+++ b/packages/frontend/scripts/dev.ts
@@ -1,8 +1,0 @@
-import { createServer } from "rolldown-vite";
-import config from "./vite.ts";
-
-const server = await createServer(
-  config({ mode: "development", command: "serve" }),
-);
-await server.listen();
-server.printUrls();

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,24 +1,23 @@
-import { defineConfig, loadEnv, PluginOption } from "rolldown-vite";
-import { normalize } from "@std/path";
+import { defineConfig, loadEnv, PluginOption } from "vite";
 import deno from "@deno/vite-plugin";
-import react from "@vitejs/plugin-react-swc";
+// import { denoPlugins } from "jsr:@luca/esbuild-deno-loader@^0.11.1";
+import react from "@vitejs/plugin-react";
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";
 // only needed for the build
-import { entryPoints } from "./generate-entry-points.ts";
+import { entryPoints } from "./scripts/generate-entry-points.ts";
 // Take all the routes and create an object with the route name as the key and the index.html as the value.
 const buildInputs = Object.fromEntries(
   entryPoints.map((path) => [path, "index.html"]),
 );
 
-const dirname = normalize(import.meta.dirname! + "/../");
 export default defineConfig(({ mode }) => {
+  const dirname = import.meta.dirname as string;
   const env = loadEnv(mode, dirname);
   return {
     build: {
       rollupOptions: {
         input: buildInputs,
-        logLevel: "debug",
       },
       outDir: "dist",
       copyPublicDir: true,
@@ -29,8 +28,8 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       deno() as PluginOption,
-      react() as PluginOption,
-      TanStackRouterVite({ addExtensions: true }) as PluginOption,
+      react(),
+      TanStackRouterVite({ addExtensions: true }),
       tailwindcss() as PluginOption,
     ],
     optimizeDeps: {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig, loadEnv, PluginOption } from "vite";
 import deno from "@deno/vite-plugin";
-// import { denoPlugins } from "jsr:@luca/esbuild-deno-loader@^0.11.1";
 import react from "@vitejs/plugin-react";
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import tailwindcss from "@tailwindcss/vite";


### PR DESCRIPTION
Reverts parts of https://github.com/masslbs/Tennessine/commit/50403f9071c5f6715240fcf3fcdb713f274dbae3

The reason is the frontend on my machine would not successfully execute with the reverted changes in place; the shop ui would never load.

In order to progress on https://github.com/masslbs/Tennessine/issues/436, I needed to have a working baseline from
which to start making changes. See https://github.com/masslbs/Tennessine/issues/436#issuecomment-2861969601 for more context on the deno-vite-plugin fix. 

----

If anyone wants to try out the faster run times using the forked `deno-vite-plugin`, I outline the procedure below.

**Note**: the first run will be slow because there is no cache, but subsequent runs (for dev or building for production) will be fast.

Anyway, the procedure:

```
git clone https://github.com/masslbs/deno-vite-plugin
``` 

Note: for the patch below to point correctly, `deno-vite-plugin` should be cloned to a directory sibling of where `Tennessine`'s repo is stored:
```
Tennessine/
    deno.json
    packages/ 
    .....
deno-vite-plugin/
```

Switch to branch `employ-cache`: 
```
git switch employ-cache
``` 

Install deps for `deno-vite-plugin` and build it:
```
npm i --include=dev
npm run build
```

Apply this patch to the root `deno.json` of Tennessine to use the forked `@deno/vite-plugin` instead of the upstream version:
```
From 428b3771d2cf418a710b9107a5eba23c875ef106 Mon Sep 17 00:00:00 2001
From: Alp <alp@mass.market>
Date: Thu, 8 May 2025 11:26:18 +0200
Subject: [PATCH] patch in deno-vite-plugin

---
 deno.json | 2 ++
 1 file changed, 2 insertions(+)

diff --git a/deno.json b/deno.json
index 84d08de..2b44df2 100644
--- a/deno.json
+++ b/deno.json
@@ -16,6 +16,8 @@
       "exclude": ["no-slow-types"]
     }
   },
+  "patch": ["../deno-vite-plugin"],
+  "unstable": ["npm-patch"],
   "fmt": {
     "exclude": [".direnv", "node_modules", ".pre-commit-config.yaml"]
   },
-- 
2.49.0
``` 

Apply it by running `echo  <patch above> | git am` or `cat <patch-in-file> | git am`.