### PR TITLE
fix(share): fix hardcoded share link

### DIFF
--- a/packages/frontend/src/components/Share.tsx
+++ b/packages/frontend/src/components/Share.tsx
@@ -1,11 +1,13 @@
 import BackButton from "./common/BackButton.tsx";
 import { useShopId } from "../hooks/useShopId.ts";
+import { useShopDomain } from "../hooks/useShopDomain.ts";
 export default function Share() {
   const { shopId } = useShopId();
+  const { protocol, shopDomain } = useShopDomain();
 
   function copyToClipboard() {
     navigator.clipboard.writeText(
-      `https://demo-shop.mass.market/listings?shopId=${shopId}`,
+      `${protocol}//${shopDomain}/listings?shopId=${shopId}`,
     );
   }
   return (
@@ -20,12 +22,12 @@ export default function Share() {
               className="border-2 border-solid mt-1 p-2 rounded w-full"
               id="shopId"
               name="shopId"
-              value={`demo-shop.mass.market/listings?shopId=${shopId}`}
+              value={`${protocol}//${shopDomain}/listings?shopId=${shopId}`}
               onChange={() => {}}
             />
             <button
               type="button"
-              className="mr-4"
+              className="mr-4 cursor-pointer"
               style={{ backgroundColor: "transparent", padding: 0 }}
               onClick={copyToClipboard}
             >

--- a/packages/frontend/src/hooks/useShopDomain.ts
+++ b/packages/frontend/src/hooks/useShopDomain.ts
@@ -1,0 +1,6 @@
+export function useShopDomain(): { protocol: string; shopDomain: string } {
+  return {
+    protocol: globalThis.location.protocol,
+    shopDomain: globalThis.location.host,
+  };
+}


### PR DESCRIPTION
This uses window.location to derive both the protocol (so http: and https: is chosen correctly, depending on the url) and the actual domain that is visited, instead of being hardcoded to demo-shop.

However the BigInt routine that converts the hex into base10 seems broken on my end, at least locally.

closes #400 #469