### PR TITLE
Populate share link with url params + show feedback on clicking copy

### DIFF
--- a/packages/frontend/src/components/Share.tsx
+++ b/packages/frontend/src/components/Share.tsx
@@ -1,8 +1,9 @@
+import { useState } from "react";
+import { useSearch } from "@tanstack/react-router";
+
 import BackButton from "./common/BackButton.tsx";
 import { useShopDomain } from "../hooks/useShopDomain.ts";
-import { useSearch } from "@tanstack/react-router";
 import { env } from "../utils/env.ts";
-import { useState } from "react";
 
 export default function Share() {
   const search = useSearch({ strict: false });


### PR DESCRIPTION
For reasons seemingly related to external libs like viem, useShopId has to operate on a base-10 version of the shop id. This however doesn't function well in the Share view. Thus this commit, which tries to source the shop id from either the url params or the env file, before defaulting to the empty string.

Also: [display feedback on clicking copied icon](https://github.com/masslbs/Tennessine/pull/478/commits/f471d03ce300025085f35931fad8f8976e13e6de)
closes #476