### PR TITLE
Add more info to success toast + improve test flake

### DIFF
--- a/packages/frontend/src/components/ListingDetail.tsx
+++ b/packages/frontend/src/components/ListingDetail.tsx
@@ -83,7 +83,11 @@ export default function ListingDetail() {
       let orderId = currentOrder?.ID;
       if (!orderId) {
         await createOrder(itemId, quantity);
-        setMsg("Item added to cart");
+        if (quantity <= 1) {
+          setMsg("Item added to cart");
+        } else {
+          setMsg(`${quantity} items added to cart`);
+        }
         return;
       }
 
@@ -128,8 +132,12 @@ export default function ListingDetail() {
         // TODO: this is a bit of a hack, since StateManager doesnt handle BaseClass[]
         updatedOrderItems.map((item: OrderedItem) => item.asCBORMap()),
       );
+      if (quantity <= 1) {
+        setMsg("Cart updated");
+      } else {
+        setMsg(`${quantity} items added to cart`);
+      }
       setQuantity(1);
-      setMsg("Cart updated");
     } catch (error) {
       errlog(`Error: changeItems ${error}`);
       setErrorMsg("There was an error updating cart");

--- a/packages/frontend/src/components/ListingDetail.tsx
+++ b/packages/frontend/src/components/ListingDetail.tsx
@@ -86,7 +86,7 @@ export default function ListingDetail() {
         if (quantity <= 1) {
           setMsg("Item added to cart");
         } else {
-          setMsg(`${quantity} items added to cart`);
+          setMsg(`${quantity} items added`);
         }
         return;
       }
@@ -135,7 +135,7 @@ export default function ListingDetail() {
       if (quantity <= 1) {
         setMsg("Cart updated");
       } else {
-        setMsg(`${quantity} items added to cart`);
+        setMsg(`${quantity} items added`);
       }
       setQuantity(1);
     } catch (error) {

--- a/packages/frontend/src/components/ListingDetail_test.tsx
+++ b/packages/frontend/src/components/ListingDetail_test.tsx
@@ -99,7 +99,10 @@ Deno.test("Check that we can render the listing details screen", {
   successToast = await screen.findByTestId("success-toast");
   expect(successToast).toBeTruthy();
   // the success toast text should have its message begin with `${initialQty}`
-  successToastText = await screen.findByTestId("success-toast-text");
+  // first off: the toast text should begin with `${initialQty}` since initialQty > 1)
+  successToastText = await screen.findByText(
+    `${initialQty} items added`,
+  );
   expect(successToastText.textContent?.startsWith(`${initialQty}`))
     .toBeTruthy();
 
@@ -127,7 +130,7 @@ Deno.test("Check that we can render the listing details screen", {
   expect(successToast).toBeTruthy();
   // now: its text should begin with `${qtyIncreasedBy}`
   successToastText = await screen.findByText(
-    `${qtyIncreasedBy} items added to cart`,
+    `${qtyIncreasedBy} items added`,
   );
   expect(successToastText.textContent?.startsWith(`${qtyIncreasedBy}`))
     .toBeTruthy();
@@ -156,7 +159,7 @@ Deno.test("Check that we can render the listing details screen", {
   expect(successToast).toBeTruthy();
   // finally: its text should begin with `${qtyIncreasedBy2}`
   successToastText = await screen.findByText(
-    `${qtyIncreasedBy2} items added to cart`,
+    `${qtyIncreasedBy2} items added`,
   );
   expect(successToastText.textContent?.startsWith(`${qtyIncreasedBy2}`))
     .toBeTruthy();

--- a/packages/frontend/src/components/ListingDetail_test.tsx
+++ b/packages/frontend/src/components/ListingDetail_test.tsx
@@ -87,12 +87,21 @@ Deno.test("Check that we can render the listing details screen", {
   const qtyIncreasedBy = 7;
   const qtyIncreasedBy2 = 3;
 
+  let successToast;
+  let successToastText;
   const purchaseQty = await screen.findByTestId("purchaseQty");
   expect(purchaseQty).toBeTruthy();
   await user.clear(purchaseQty);
   await user.type(purchaseQty, `${initialQty}`);
   const addToBasket = screen.getByTestId("addToBasket");
   await user.click(addToBasket);
+  // wait for the success toast to appear
+  successToast = await screen.findByTestId("success-toast");
+  expect(successToast).toBeTruthy();
+  // the success toast text should have its message begin with `${initialQty}`
+  successToastText = await screen.findByTestId("success-toast-text");
+  expect(successToastText.textContent?.startsWith(`${initialQty}`))
+    .toBeTruthy();
 
   allOrders = await stateManager.get(["Orders"]) as Map<string, unknown>;
   expect(allOrders.size).toBe(1);
@@ -113,6 +122,15 @@ Deno.test("Check that we can render the listing details screen", {
   await user.type(purchaseQty2, `${qtyIncreasedBy}`);
   const addToBasket2 = screen.getByTestId("addToBasket");
   await user.click(addToBasket2);
+  // wait for the success toast to appear
+  successToast = await screen.findByTestId("success-toast");
+  expect(successToast).toBeTruthy();
+  // now: its text should begin with `${qtyIncreasedBy}`
+  successToastText = await screen.findByText(
+    `${qtyIncreasedBy} items added to cart`,
+  );
+  expect(successToastText.textContent?.startsWith(`${qtyIncreasedBy}`))
+    .toBeTruthy();
 
   const d = await stateManager.get(["Orders", orderId]);
   expect(d).toBeDefined();
@@ -128,13 +146,21 @@ Deno.test("Check that we can render the listing details screen", {
   const purchaseQty3 = await screen.findByTestId("purchaseQty");
   expect(purchaseQty3).toBeTruthy();
   await user.clear(purchaseQty3);
+
   // Third quantity update
   await user.type(purchaseQty3, `${qtyIncreasedBy2}`);
   const addToBasket3 = screen.getByTestId("addToBasket");
   await user.click(addToBasket3);
-
-  const successToast = await screen.findByTestId("success-toast");
+  // wait for the success toast to appear
+  successToast = await screen.findByTestId("success-toast");
   expect(successToast).toBeTruthy();
+  // finally: its text should begin with `${qtyIncreasedBy2}`
+  successToastText = await screen.findByText(
+    `${qtyIncreasedBy2} items added to cart`,
+  );
+  expect(successToastText.textContent?.startsWith(`${qtyIncreasedBy2}`))
+    .toBeTruthy();
+
   let updatedOrders;
   await waitFor(async () => {
     updatedOrders = await stateManager.get(["Orders"]) as Map<

--- a/packages/frontend/src/components/common/SuccessToast.tsx
+++ b/packages/frontend/src/components/common/SuccessToast.tsx
@@ -19,7 +19,7 @@ export default function SuccessToast(
       className="px-4 py-2 bg-success-green text-white font-thin rounded-lg flex items-center"
       data-testid="success-toast"
     >
-      <p>{message}</p>
+      <p data-testid="success-toast-text">{message}</p>
       {cta
         ? (
           <Link

--- a/packages/frontend/src/components/common/SuccessToast.tsx
+++ b/packages/frontend/src/components/common/SuccessToast.tsx
@@ -19,7 +19,7 @@ export default function SuccessToast(
       className="px-4 py-2 bg-success-green text-white font-thin rounded-lg flex items-center"
       data-testid="success-toast"
     >
-      <p data-testid="success-toast-text">{message}</p>
+      <p>{message}</p>
       {cta
         ? (
           <Link


### PR DESCRIPTION
Changed the success toast displayed on ListingDetail to include more information about the quantity that was just added. Then used this information to improve the ListingDetail test by using a findByText query, which waits for the appearance of its input for a certain amount of time.

The hope is that waiting for the success toast to change gives the stateManager logic enough time to run and actually finish updating the quantity internal, making this particular test flake less often in CI.