### PR TITLE
fix(Listings.tsx): move useEffect above conditional return

### DIFF
--- a/packages/frontend/src/components/Listings.tsx
+++ b/packages/frontend/src/components/Listings.tsx
@@ -16,18 +16,6 @@ export default function Listings() {
   const [keycard] = useKeycard();
   const [products, setProducts] = useState<Listing[]>([]);
 
-  if (!stateManager) {
-    return <main data-testid="listings-page">Loading...</main>;
-  }
-
-  function mapToListingClass(allListings: Map<CodecKey, CodecValue>) {
-    const listings: Listing[] = [];
-    for (const [_id, l] of allListings.entries()) {
-      listings.push(Listing.fromCBOR(l));
-    }
-    return listings;
-  }
-
   useEffect(() => {
     if (!stateManager) return;
 
@@ -54,6 +42,18 @@ export default function Listings() {
       );
     };
   }, [stateManager]);
+
+  if (!stateManager) {
+    return <main data-testid="listings-page">Loading...</main>;
+  }
+
+  function mapToListingClass(allListings: Map<CodecKey, CodecValue>) {
+    const listings: Listing[] = [];
+    for (const [_id, l] of allListings.entries()) {
+      listings.push(Listing.fromCBOR(l));
+    }
+    return listings;
+  }
 
   return (
     <main


### PR DESCRIPTION
After my fix to speed up the frontend[1], I was now getting an error from React when rendering the shop interface as a guest during development:

> "Rendered more hooks than during the previous render." / https://react.dev/errors/310

The problem: all hooks need to be consistently rendered across runs.

That is a hook like `useEffect` should be always be called if it is defined in a component, i.e. it should not be called conditionally.

What seems to have been happening is that since my interface was now rendering faster, I ran into stateManager not having been set yet (whereas with the slowdown it was never happening, I presume). This caused the hook to sometimes be set, sometimes not, yielding React's hooks error.

I moved the useEffect call to above the return and that cleared it up locally.

[1]: https://github.com/masslbs/deno-vite-plugin/tree/employ-cache