### PR TITLE
State manager promise strictness

### DIFF
--- a/packages/stateManager/mod.ts
+++ b/packages/stateManager/mod.ts
@@ -100,25 +100,25 @@ export default class StateManager {
           // TODO validate the Operation's value if any
           // console.log("Applying patch:", patch);
           if (patch.Op === "add") {
-            state.root = await this.graph.add(
+            state.root = this.graph.add(
               state.root,
               patch.Path,
               patch.Value,
             );
           } else if (patch.Op === "replace") {
-            state.root = await this.graph.set(
+            state.root = this.graph.set(
               state.root,
               patch.Path,
               patch.Value,
             );
           } else if (patch.Op === "append") {
-            state.root = await this.graph.append(
+            state.root = this.graph.append(
               state.root,
               patch.Path,
               patch.Value,
             );
           } else if (patch.Op === "remove") {
-            state.root = await this.graph.remove(
+            state.root = this.graph.remove(
               state.root,
               patch.Path,
             );
@@ -142,8 +142,8 @@ export default class StateManager {
 
         state.subscriptionSequenceNumber = patchSet.sequence;
         // we want to wait to resolve the promise before emitting the new state
-        state.root = await state.root;
-        this.events.emit(state.root);
+        const realState = await state.root;
+        this.events.emit(realState);
         // TODO: check stateroot
         // TODO: we are saving the patches here
         // incase we want to replay the log, but we have no way to get them out

--- a/packages/stateManager/patching_test.ts
+++ b/packages/stateManager/patching_test.ts
@@ -88,7 +88,8 @@ Deno.test("Database Testings", async (t) => {
             if (skippedAfterCheck.has(test.description)) {
               console.log("Skipping state check!!!!!!!");
             } else {
-              assertEquals(sm.root, after);
+              const r = await sm.root;
+              assertEquals(r, after);
             }
             await sm.close();
           });


### PR DESCRIPTION
This is in response to https://github.com/masslbs/Tennessine/issues/499
There is a possible race condition in the stateManger. Using  `state.root = await X` causes a race condition,  `state.root` must always be set atomically. Lets consider why. 

Lets say the stateManger recieves a patchset from the relay. While applying the patch's it sets the state to  `state.root<v1> = await updatingTheStateFunction`. 

Now lets say stateManger.set is called. at this point `updatingTheStateFunction`  may have not resolved and state.root is now stale as stateManger.set is operating on `state.root<v1>`. When `stateManger.set` finishes its update it sets a new state root: `state.root<v2>`. Lastly `updatingTheStateFunction` finishes and `state.root = await updatingTheStateFunction` sets the state.root to `state.root<v3>` = Result(updatingTheStateFunction(`state.root<v1>`)) which reverts state.root<v2> produced by stateManger.set