### PR TITLE
remove validation  for stock being set to 0

### DIFF
--- a/packages/frontend/src/components/merchants/listings/EditListing.tsx
+++ b/packages/frontend/src/components/merchants/listings/EditListing.tsx
@@ -121,8 +121,6 @@ export default function EditProduct() {
       setValidationError("Product must include price.");
     } else if (!newListing.Metadata.Images?.length) {
       setValidationError("Product must include image.");
-    } else if (!stock) {
-      setValidationError("Number of stock cannot be 0.");
     } else {
       try {
         setPublishing(true);

--- a/packages/frontend/src/hooks/useShopId.ts
+++ b/packages/frontend/src/hooks/useShopId.ts
@@ -10,9 +10,7 @@ export function useShopId() {
     };
   }
   const search = useSearch({ strict: false });
-  if (!search?.shopId) {
-    globalThis.location.href = env.primaryExternalURL;
-  }
+
   return {
     shopId: search?.shopId ? hexToBigInt(search.shopId, { size: 32 }) : null,
   };


### PR DESCRIPTION
Closes #511 

I misunderstood the issue for issue #511. 
1. This PR allows merchant to set stock to 0 by removing the validation that prevents user from setting stock to 0.

2. I am also removing the redirect to primary external link if no shop ID is provided in search param, because this causes unexpected issues in /create-shop. 

- Because the removed code will redirect to mass.market before [this](https://github.com/masslbs/Tennessine/blob/main/packages/frontend/src/components/merchants/create-shop/CreateShop.tsx#L105)  code in CreateShop - which sets the shop id in the url.

But issue #517 will resolve the cases with not having id as search param anyway which is in my priority bucket.