### PR TITLE
fix(ListingDetail): display description w/ newlines intact

### DIFF
--- a/packages/frontend/src/components/ListingDetail.tsx
+++ b/packages/frontend/src/components/ListingDetail.tsx
@@ -140,6 +140,10 @@ export default function ListingDetail() {
     }
   }
 
+  function splitTextByNewlines(input: string) {
+    return input.split("\n");
+  }
+
   return (
     <main
       className="bg-gray-100 md:flex justify-center"
@@ -221,7 +225,15 @@ export default function ListingDetail() {
           <section className="flex gap-4 flex-col bg-white mt-5 md:mt-0 rounded-md md:w-2/5 p-4">
             <div>
               <h3 className=" ">Description</h3>
-              <p data-testid="description">{listing.Metadata.Description}</p>
+              <section data-testid="description">
+                {splitTextByNewlines(listing.Metadata.Description).map(
+                  (line: string, index: number) => (
+                    <p key={`description-${index}`} className="min-h-[1ch]">
+                      {line}
+                    </p>
+                  ),
+                )}
+              </section>
             </div>
             <div className="flex gap-2 items-center mt-auto">
               <img


### PR DESCRIPTION
closes #503

note: This patch assumes that `<listing>.Metadata.Description` will always be a string

Tangentially related to #500 