### PR TITLE
fix grey out for page when nav modal is open

### DIFF
--- a/packages/frontend/src/components/CustomerViewListings.tsx
+++ b/packages/frontend/src/components/CustomerViewListings.tsx
@@ -74,7 +74,7 @@ export default function CustomerViewProducts({
                   className="w-5 h-5"
                   data-testid="coin-icon"
                 />
-                <p data-testid="product-price">
+                <p data-testid="product-price" className="truncate">
                   {formatUnits(item.Price, baseToken.decimals)}
                 </p>
               </div>

--- a/packages/frontend/src/components/Navigation.tsx
+++ b/packages/frontend/src/components/Navigation.tsx
@@ -180,8 +180,17 @@ function Navigation() {
 
   return (
     <section>
+      {(basketOpen || menuOpen) && (
+        <span
+          className="fixed bg-black w-full h-full opacity-60 z-5"
+          onClick={() => {
+            basketOpen && setBasketOpen(false);
+            menuOpen && setMenuOpen(false);
+          }}
+        />
+      )}
       <section
-        className={`bg-white flex justify-center`}
+        className={`bg-white flex justify-center z-10 relative`}
         data-testid="navigation"
       >
         <section className="relative w-full text-base flex justify-between md:w-[800px] h-[56px] mr-3">
@@ -315,15 +324,6 @@ function Navigation() {
           </section>
         </section>
       </section>
-      {(cartVisible || menuOpen) && (
-        <span
-          className="fixed bg-black w-full h-full opacity-60 z-5"
-          onClick={() => {
-            cartVisible && setCartVisible(false);
-            menuOpen && setMenuOpen(false);
-          }}
-        />
-      )}
       <section id="mobile-menu" className="md:hidden absolute z-10">
         {menuOpen
           ? (

--- a/packages/frontend/src/components/Navigation.tsx
+++ b/packages/frontend/src/components/Navigation.tsx
@@ -180,11 +180,11 @@ function Navigation() {
 
   return (
     <section>
-      {(basketOpen || menuOpen) && (
+      {(cartVisible || menuOpen) && (
         <span
           className="fixed bg-black w-full h-full opacity-60 z-5"
           onClick={() => {
-            basketOpen && setBasketOpen(false);
+            cartVisible && setCartVisible(false);
             menuOpen && setMenuOpen(false);
           }}
         />

--- a/packages/frontend/src/components/merchants/listings/MerchantViewListings.tsx
+++ b/packages/frontend/src/components/merchants/listings/MerchantViewListings.tsx
@@ -96,7 +96,7 @@ export default function MerchantViewProducts({
                   height={20}
                   className="w-5 h-5"
                 />
-                <p data-testid={`product-price`}>
+                <p data-testid="product-price" className="truncate">
                   {formatUnits(item.Price, baseToken.decimals)}
                 </p>
               </div>


### PR DESCRIPTION
**1.** truncates super long prices 
![image](https://github.com/user-attachments/assets/342a6b6a-52a8-448d-8dfa-c2133139e811)

**2.** grey overlay covers the entirety of the screen when one of the nav modals are open. (closes #392)

![image](https://github.com/user-attachments/assets/dcf88868-bc5f-4f3a-8c0e-a6f767d17e83)

![image](https://github.com/user-attachments/assets/bb9c6920-996c-4593-9474-a3d4421c0e98)

![image](https://github.com/user-attachments/assets/480bac51-af7c-4c78-a2a0-dfd3bbea4ca3)

