### PR TITLE
This creates a 'config' record in the context 

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -11,14 +11,16 @@ const router = createRouter({ routeTree });
 
 export default function App({
   wagmiConfig = config,
+  massMarketConfig = {},
 }: {
   wagmiConfig?: ReturnType<typeof getDefaultConfig> | Config;
   children?: React.ReactNode;
+  massMarketConfig?: Record<string, string>;
 }) {
   return (
     <QueryClientProvider client={queryClient}>
       <WagmiProvider config={wagmiConfig}>
-        <MassMarketProvider>
+        <MassMarketProvider config={massMarketConfig}>
           <RainbowKitProvider showRecentTransactions>
             <RouterProvider router={router} />
             <main data-testid="homepage">

--- a/packages/frontend/src/MassMarketContext.ts
+++ b/packages/frontend/src/MassMarketContext.ts
@@ -1,14 +1,14 @@
-import React, {
+import {
   createContext,
   createElement,
-  Dispatch,
-  SetStateAction,
+  type Dispatch,
+  type SetStateAction,
   useContext,
   useState,
 } from "react";
-import { Order } from "@massmarket/schema";
-import { RelayClient } from "@massmarket/client";
-import StateManager from "@massmarket/stateManager";
+import type { Order } from "@massmarket/schema";
+import type { RelayClient } from "@massmarket/client";
+import type StateManager from "@massmarket/stateManager";
 
 type MassMarketContextType = {
   relayClient: RelayClient | undefined;
@@ -24,6 +24,7 @@ type MassMarketContextType = {
   >;
   currentOrder: Order | null;
   setCurrentOrder: Dispatch<SetStateAction<Order | null>>;
+  config: Record<string, string>;
 };
 
 export const MassMarketContext = createContext<
@@ -36,6 +37,7 @@ export function MassMarketProvider(
   parameters: React.PropsWithChildren<{
     relayClient?: RelayClient;
     stateManager?: StateManager;
+    config?: Record<string, string>;
   }>,
 ) {
   const [relayClient, setRelayClient] = useState(
@@ -59,6 +61,7 @@ export function MassMarketProvider(
     setShopDetails,
     currentOrder,
     setCurrentOrder,
+    config: parameters.config || {},
   };
 
   return createElement(MassMarketContext.Provider, {

--- a/packages/frontend/src/components/Share.tsx
+++ b/packages/frontend/src/components/Share.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useSearch } from "@tanstack/react-router";
 
 import BackButton from "./common/BackButton.tsx";
-import { env } from "../utils/env.ts";
+import { useMassMarketContext } from "../MassMarketContext.ts";
 
 export function useShopDomain() {
   return {
@@ -13,6 +13,7 @@ export function useShopDomain() {
 
 export default function Share() {
   const search = useSearch({ strict: false });
+  const { config: env } = useMassMarketContext();
   const shopId = search?.shopId || env.shopTokenId || "";
   const { protocol, shopDomain } = useShopDomain();
   const [copiedToClipboard, setCopied] = useState<boolean>(false);

--- a/packages/frontend/src/components/cart/Pay.tsx
+++ b/packages/frontend/src/components/cart/Pay.tsx
@@ -17,7 +17,7 @@ import { abi, approveERC20, getAllowance, pay } from "@massmarket/contracts";
 
 import Button from "../common/Button.tsx";
 import BackButton from "../common/BackButton.tsx";
-import { env } from "../../utils/env.ts";
+import { useMassMarketContext } from "../../MassMarketContext.ts";
 import { isTesting } from "../../utils/env.ts";
 import ErrorMessage from "../common/ErrorMessage.tsx";
 import PriceSummary from "./PriceSummary.tsx";
@@ -25,7 +25,6 @@ import PriceSummary from "./PriceSummary.tsx";
 const logger = getLogger(["mass-market", "frontend", "pay"]);
 
 const defaultShopChainName = isTesting ? "hardhat" : "mainnet";
-const configuredChainName = env.chainName || defaultShopChainName;
 
 const {
   eddiesAbi,
@@ -53,6 +52,9 @@ export default function Pay({
   const { connector } = useAccount();
   const { data: wallet } = useWalletClient();
   const chainId = useChainId();
+  const { config: env } = useMassMarketContext();
+
+  const configuredChainName = env.chainName || defaultShopChainName;
 
   const paymentChainId = Number(paymentArgs?.[0]?.chainId);
   // TODO: might want to do this in a hook

--- a/packages/frontend/src/components/merchants/OrderDetails.tsx
+++ b/packages/frontend/src/components/merchants/OrderDetails.tsx
@@ -16,7 +16,6 @@ import BackButton from "../common/BackButton.tsx";
 import { ListingId, OrderState } from "../../types.ts";
 import { useStateManager } from "../../hooks/useStateManager.ts";
 import { useBaseToken } from "../../hooks/useBaseToken.ts";
-import { env } from "../../utils/env.ts";
 import { formatDate, getTokenInformation } from "../../utils/mod.ts";
 
 const logger = getLogger(["mass-market", "frontend", "order-details"]);
@@ -90,7 +89,7 @@ export default function OrderDetails() {
       }
       const tokenPublicClient = createPublicClient({
         chain,
-        transport: http(env.ethRPCUrl),
+        transport: http(),
       });
       getTokenInformation(
         tokenPublicClient,

--- a/packages/frontend/src/hooks/useChain.ts
+++ b/packages/frontend/src/hooks/useChain.ts
@@ -1,9 +1,10 @@
+import { useMassMarketContext } from "../MassMarketContext.ts";
 import { type Chain, hardhat, mainnet, sepolia } from "viem/chains";
-import { env } from "../utils/env.ts";
 
 export function useChain() {
+  const context = useMassMarketContext();
   let chain: Chain;
-  switch (env.chainName) {
+  switch (context.config.chainName) {
     case "sepolia":
       chain = sepolia;
       break;
@@ -14,7 +15,7 @@ export function useChain() {
       chain = hardhat;
       break;
     default:
-      throw new Error(`Unknown chain: ${env.chainName}`);
+      throw new Error(`Unknown chain: ${context.config.chainName}`);
   }
   return { chain };
 }

--- a/packages/frontend/src/hooks/useRelayEndpoint.ts
+++ b/packages/frontend/src/hooks/useRelayEndpoint.ts
@@ -1,19 +1,20 @@
 import { getLogger } from "@logtape/logtape";
-import { discoverRelay } from "@massmarket/client";
+import { discoverRelay, IRelayEndpoint } from "@massmarket/client";
 import { useQuery } from "@tanstack/react-query";
-import { env } from "../utils/env.ts";
+import { useMassMarketContext } from "../MassMarketContext.ts";
 
 const logger = getLogger(["mass-market", "frontend", "useRelayEndpoint"]);
 
 export function useRelayEndpoint() {
+  const { config: env } = useMassMarketContext();
   const q = useQuery(
     {
       queryKey: ["relayEndpoint"],
       queryFn: async () => {
         if (env.relayTokenId && env.relayEndpoint) {
-          const re = {
+          const re: IRelayEndpoint = {
             url: new URL(env.relayEndpoint),
-            tokenId: env.relayTokenId,
+            tokenId: env.relayTokenId as `0x${string}`,
           };
           logger.debug(
             `using environment variables for relay endpoint ${re.url}`,

--- a/packages/frontend/src/hooks/useRelayEndpoint_test.ts
+++ b/packages/frontend/src/hooks/useRelayEndpoint_test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "@std/assert";
 import { renderHook } from "@testing-library/react";
 import { useRelayEndpoint } from "./useRelayEndpoint.ts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MassMarketProvider } from "../MassMarketContext.ts";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -13,7 +14,9 @@ const queryClient = new QueryClient({
 });
 
 function wrapper({ children }: { children: React.ReactNode }) {
-  return QueryClientProvider({ client: queryClient, children });
+  return MassMarketProvider({
+    children: QueryClientProvider({ client: queryClient, children }),
+  });
 }
 
 Deno.test("useRelayEndpoint", async (t) => {
@@ -27,6 +30,5 @@ Deno.test("useRelayEndpoint", async (t) => {
     rerender();
     assertEquals(!!result.current.relayEndpoint, true);
   });
-
   await GlobalRegistrator.unregister();
 });

--- a/packages/frontend/src/hooks/useShopId.ts
+++ b/packages/frontend/src/hooks/useShopId.ts
@@ -1,8 +1,9 @@
 import { useSearch } from "@tanstack/react-router";
 import { hexToBigInt } from "viem";
-import { env } from "../utils/env.ts";
+import { useMassMarketContext } from "../MassMarketContext.ts";
 
 export function useShopId() {
+  const { config: env } = useMassMarketContext();
   // This is for prod builds so we can have a clean url without having to include shopId in the param.
   if (env.shopTokenId) {
     return {

--- a/packages/frontend/src/hooks/useStateManager.ts
+++ b/packages/frontend/src/hooks/useStateManager.ts
@@ -9,7 +9,6 @@ import StateManager from "@massmarket/stateManager";
 import { useRouter } from "@tanstack/react-router";
 
 import { KeycardRole } from "../types.ts";
-import { env } from "../utils/env.ts";
 import { useMassMarketContext } from "../MassMarketContext.ts";
 import { useShopId } from "./useShopId.ts";
 import { useQuery } from "./useQuery.ts";
@@ -83,9 +82,7 @@ export function useStateManager() {
         const keycardWallet = createWalletClient({
           account,
           chain,
-          transport: http(
-            env.ethRPCUrl,
-          ),
+          transport: http(),
         });
         const res = await relayClient.enrollKeycard(
           keycardWallet,

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -37,6 +37,6 @@ await configure(sentryConfig);
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
-    <App />
+    <App massMarketConfig={env} />
   </StrictMode>,
 );

--- a/packages/frontend/src/testutils/mod.tsx
+++ b/packages/frontend/src/testutils/mod.tsx
@@ -24,6 +24,7 @@ import { MemStore } from "@massmarket/store";
 
 import { MassMarketProvider } from "../MassMarketContext.ts";
 import { KeycardRole } from "../types.ts";
+import { env } from "../utils/env.ts";
 
 export const relayURL = Deno.env.get("RELAY_ENDPOINT") ||
   "http://localhost:4444/v4";
@@ -226,6 +227,7 @@ export const createRouterWrapper = async ({
             <MassMarketProvider
               stateManager={stateManager}
               relayClient={relayClient}
+              config={env}
             >
               <RainbowKitProvider showRecentTransactions>
                 {


### PR DESCRIPTION
which replaces most of the uses of .env vars. Instead the app uses .env vars to set the config record.
This helps decouple the underlining components and hooks from the top level app, by trying to isolate where .env are interacted with to top level entry files. 