### PR TITLE
update constants for new order locking states

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,6 +26,7 @@
       "original": {
         "owner": "masslbs",
         "repo": "contracts",
+        "rev": "548ca6e00ffe3f8d841fa4aa985183f0ff3b4dc3",
         "type": "github"
       }
     },
@@ -80,11 +81,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -96,11 +97,11 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -112,11 +113,27 @@
     "flake-compat_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -166,11 +183,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1753121425,
-        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -184,11 +201,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -202,11 +219,29 @@
         "nixpkgs-lib": "nixpkgs-lib_5"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1754420989,
+        "narHash": "sha256-3e4wHzNwTMg7GaeLH9A091DMaO9AfFxUjpfqbddCUeo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "7f38f25a44023a21a504bd3fd9d4f41c4a39f55c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_6": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_6"
+      },
+      "locked": {
+        "lastModified": 1754420989,
+        "narHash": "sha256-3e4wHzNwTMg7GaeLH9A091DMaO9AfFxUjpfqbddCUeo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "7f38f25a44023a21a504bd3fd9d4f41c4a39f55c",
         "type": "github"
       },
       "original": {
@@ -247,7 +282,25 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -350,6 +403,7 @@
         "nixpkgs": [
           "relay",
           "pystoretest",
+          "network-schema",
           "pre-commit-hooks",
           "nixpkgs"
         ]
@@ -369,6 +423,29 @@
       }
     },
     "gitignore_5": {
+      "inputs": {
+        "nixpkgs": [
+          "relay",
+          "pystoretest",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_6": {
       "inputs": {
         "nixpkgs": [
           "relay",
@@ -396,6 +473,31 @@
         "flake-utils": "flake-utils",
         "nixpkgs": [
           "relay",
+          "pystoretest",
+          "network-schema",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733764984,
+        "narHash": "sha256-4pHRrZ6bvk4+2XrM4MNaqkcoO+DecjZtFoJcJm9Fab0=",
+        "owner": "obreitwi",
+        "repo": "gomod2nix",
+        "rev": "9048c4bd5c1c1a48f55760d920617cc3ce6c685b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "obreitwi",
+        "ref": "fix/go_mod_vendor",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "gomod2nix_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "relay",
           "schema",
           "nixpkgs"
         ]
@@ -412,6 +514,29 @@
         "owner": "obreitwi",
         "ref": "fix/go_mod_vendor",
         "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "network-schema": {
+      "inputs": {
+        "flake-parts": "flake-parts_5",
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs_3",
+        "pre-commit-hooks": "pre-commit-hooks_4",
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1756286342,
+        "narHash": "sha256-s734Zb9hkhlfDvN3k56CZpjHaNrJ5MxYx3vNmdrNdmM=",
+        "owner": "masslbs",
+        "repo": "network-schema",
+        "rev": "a3e0d2517ff280dbb37d98235f2241ea34b8660b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "masslbs",
+        "ref": "order-locking-states",
+        "repo": "network-schema",
         "type": "github"
       }
     },
@@ -463,11 +588,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
         "type": "github"
       },
       "original": {
@@ -478,11 +603,11 @@
     },
     "nixpkgs-lib_4": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
         "type": "github"
       },
       "original": {
@@ -493,11 +618,26 @@
     },
     "nixpkgs-lib_5": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_6": {
+      "locked": {
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
         "type": "github"
       },
       "original": {
@@ -523,11 +663,27 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1752436162,
-        "narHash": "sha256-Kt1UIPi7kZqkSc5HVj6UY5YLHHEzPBkgpNUByuyxtlw=",
+        "lastModified": 1754292888,
+        "narHash": "sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I+5OPGEmIE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dfcd5b901dbab46c9c6e80b265648481aafb01f8",
+        "rev": "ce01daebf8489ba97bd1609d185ea276efdeb121",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1754292888,
+        "narHash": "sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I+5OPGEmIE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ce01daebf8489ba97bd1609d185ea276efdeb121",
         "type": "github"
       },
       "original": {
@@ -625,11 +781,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
-        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "lastModified": 1755960406,
+        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
         "type": "github"
       },
       "original": {
@@ -645,15 +801,16 @@
         "nixpkgs": [
           "relay",
           "pystoretest",
+          "network-schema",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
-        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "lastModified": 1754416808,
+        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
         "type": "github"
       },
       "original": {
@@ -668,16 +825,40 @@
         "gitignore": "gitignore_5",
         "nixpkgs": [
           "relay",
+          "pystoretest",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755960406,
+        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_6": {
+      "inputs": {
+        "flake-compat": "flake-compat_6",
+        "gitignore": "gitignore_6",
+        "nixpkgs": [
+          "relay",
           "schema",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
-        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "lastModified": 1754416808,
+        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
         "type": "github"
       },
       "original": {
@@ -723,28 +904,25 @@
           "contracts"
         ],
         "flake-parts": "flake-parts_4",
-        "network-schema": [
-          "relay",
-          "schema"
-        ],
+        "network-schema": "network-schema",
         "nixpkgs": [
           "relay",
           "nixpkgs"
         ],
-        "pre-commit-hooks": "pre-commit-hooks_4",
-        "systems": "systems_2"
+        "pre-commit-hooks": "pre-commit-hooks_5",
+        "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1752584278,
-        "narHash": "sha256-elFctvPIXyNuDKQyhwTfsyYAKl1DLWWqTuPE3xahl6k=",
+        "lastModified": 1756287383,
+        "narHash": "sha256-41nfvcpr0D2XbhKKas3flUKumvmUAcn+b3GVXRfLXF4=",
         "owner": "masslbs",
         "repo": "pystoretest",
-        "rev": "b3c09cf6bc4ba272f45c004d5cde218fceaeaa7e",
+        "rev": "3bbf1042b3b6aa5aea80966141b6b850c8225dfd",
         "type": "github"
       },
       "original": {
         "owner": "masslbs",
-        "ref": "network-v5",
+        "ref": "order-state-locking",
         "repo": "pystoretest",
         "type": "github"
       }
@@ -763,19 +941,19 @@
         "pystoretest": "pystoretest",
         "schema": "schema",
         "services-flake": "services-flake_2",
-        "systems": "systems_5"
+        "systems": "systems_7"
       },
       "locked": {
-        "lastModified": 1753693243,
-        "narHash": "sha256-wG6q6ehvS5mJwwdWyRMDXF6MD2T9QYf+cMybgb1p5sQ=",
+        "lastModified": 1756303536,
+        "narHash": "sha256-R57aFnhOfspVAGa5di9IEQ4H3r0mGKGMjHwxjPX9jl4=",
         "owner": "masslbs",
         "repo": "relay",
-        "rev": "a53d1f7a68b994e9e1aaf4a6f3de78a5c40dd9bc",
+        "rev": "8d561d634bfffe9fbcf8d247c870a1b7f8996a8b",
         "type": "github"
       },
       "original": {
         "owner": "masslbs",
-        "ref": "network-v5",
+        "ref": "order-state-locking",
         "repo": "relay",
         "type": "github"
       }
@@ -795,28 +973,28 @@
           "relay",
           "schema"
         ],
-        "systems": "systems_6"
+        "systems": "systems_8"
       }
     },
     "schema": {
       "inputs": {
-        "flake-parts": "flake-parts_5",
-        "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs_3",
-        "pre-commit-hooks": "pre-commit-hooks_5",
-        "systems": "systems_4"
+        "flake-parts": "flake-parts_6",
+        "gomod2nix": "gomod2nix_2",
+        "nixpkgs": "nixpkgs_4",
+        "pre-commit-hooks": "pre-commit-hooks_6",
+        "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1752579397,
-        "narHash": "sha256-oMteduiz/PqwHCyaZcM6tqV2qUhq0YP9nodVCSpFaX8=",
+        "lastModified": 1756286342,
+        "narHash": "sha256-s734Zb9hkhlfDvN3k56CZpjHaNrJ5MxYx3vNmdrNdmM=",
         "owner": "masslbs",
         "repo": "network-schema",
-        "rev": "d871509aea925438a57600fb66484db535e7a1b9",
+        "rev": "a3e0d2517ff280dbb37d98235f2241ea34b8660b",
         "type": "github"
       },
       "original": {
         "owner": "masslbs",
-        "ref": "v5-dev",
+        "ref": "order-locking-states",
         "repo": "network-schema",
         "type": "github"
       }
@@ -838,11 +1016,11 @@
     },
     "services-flake_2": {
       "locked": {
-        "lastModified": 1753692092,
-        "narHash": "sha256-NVSIHHFwzstRofPkDvkrMqXBhT7isIiAaRjTi0qvJvk=",
+        "lastModified": 1755996515,
+        "narHash": "sha256-1RQQIDhshp1g4PP5teqibcFLfk/ckTDOJRckecAHiU0=",
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "b82d7cde1cc846e5dad4dc5777574ed808e74c2d",
+        "rev": "e316d6b994fd153f0c35d54bd07d60e53f0ad9a9",
         "type": "github"
       },
       "original": {
@@ -943,6 +1121,36 @@
       }
     },
     "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_8": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    relay.url = "github:masslbs/relay/network-v5";
+    relay.url = "github:masslbs/relay/order-state-locking";
     contracts.follows = "relay/contracts";
     schema.follows = "relay/schema";
     # in case we need to test new vectors, etc. we can override the input like this:

--- a/packages/frontend/src/components/ListingDetail_test.tsx
+++ b/packages/frontend/src/components/ListingDetail_test.tsx
@@ -130,7 +130,7 @@ Deno.test(
       // Commit order and try to update quantity. Tests cancelAndRecreateOrder fn
       await stateManager.set(
         ["Orders", orderId!, "PaymentState"],
-        OrderPaymentState.Committed,
+        OrderPaymentState.Locked,
       );
 
       // Here we are updating the listing pricing.

--- a/packages/frontend/src/components/cart/Cart.tsx
+++ b/packages/frontend/src/components/cart/Cart.tsx
@@ -184,7 +184,7 @@ export default function Cart({
       if (activeOrder!.PaymentState === OrderPaymentState.Open) {
         await stateManager!.set(
           ["Orders", activeOrder!.ID, "PaymentState"],
-          OrderPaymentState.Committed,
+          OrderPaymentState.Locked,
         );
         logger.debug(`Order ID: ${activeOrder!.ID} committed`);
       }

--- a/packages/frontend/src/components/cart/Cart_test.tsx
+++ b/packages/frontend/src/components/cart/Cart_test.tsx
@@ -374,7 +374,7 @@ const createTestComponent = (oId: number, commitOrder: boolean) => {
         if (!commitOrder) return;
         stateManager.set(
           ["Orders", oId, "PaymentState"],
-          OrderPaymentState.Committed,
+          OrderPaymentState.Locked,
         );
       });
     }, [listingsLoaded]);

--- a/packages/frontend/src/components/cart/Checkout_test.tsx
+++ b/packages/frontend/src/components/cart/Checkout_test.tsx
@@ -438,7 +438,7 @@ const createTestComponent = (
       stateManager.set(["Orders", orderId], order).then(() => {
         stateManager.set(
           ["Orders", orderId, "PaymentState"],
-          OrderPaymentState.Committed,
+          OrderPaymentState.Locked,
         );
       });
       stateManager.set(

--- a/packages/frontend/src/components/merchants/MerchantDashboard_test.tsx
+++ b/packages/frontend/src/components/merchants/MerchantDashboard_test.tsx
@@ -70,7 +70,7 @@ Deno.test(
             "Open",
           );
           expect(within(committed[0]).getByTestId("status").textContent).toBe(
-            "Committed",
+            "Locked",
           );
         });
         unmount();

--- a/packages/schema/standin_order.ts
+++ b/packages/schema/standin_order.ts
@@ -208,12 +208,14 @@ export class OrderedItem extends BaseClass {
 
 export enum OrderPaymentState {
   Unspecified,
-  Open,
   Canceled,
-  Committed,
+  Open,
+  Locked,
   PaymentChosen,
   Unpaid,
+  UnpaidExpired,
   Paid,
+  PaidLate,
 }
 
 export class AddressDetails extends BaseClass {


### PR DESCRIPTION
This brings

- the new relay version which supports unlocking of orders to local-testnet
- updates the constants of OrderPaymentState
- the relay now updates the inventory when orders are (un)locked