### PR TITLE
useOrderItemsInventory hook to get all stock and set up event listeners

### DIFF
--- a/packages/frontend/src/components/common/OrderWarningModal.tsx
+++ b/packages/frontend/src/components/common/OrderWarningModal.tsx
@@ -1,0 +1,27 @@
+import Button from "./Button.tsx";
+import Modal from "./Modal.tsx";
+
+export default function OrderWarningModal(
+  { showModal, proceed, reset }: {
+    showModal: boolean;
+    proceed: () => void;
+    reset: () => void;
+  },
+) {
+  if (!showModal) return null;
+
+  return (
+    <Modal>
+      <h2 className="mb-4">Before you leave...</h2>
+      <p>If you leave this page, your items will no longer be reserved.</p>
+      <section className="mt-5 flex gap-3">
+        <Button onClick={() => reset()}>
+          Continue checkout
+        </Button>
+        <Button onClick={proceed}>
+          Back to shop
+        </Button>
+      </section>
+    </Modal>
+  );
+}

--- a/packages/react-hooks/mod.ts
+++ b/packages/react-hooks/mod.ts
@@ -12,3 +12,4 @@ export * from "./useShopDetails.ts";
 export * from "./useShopPublicClient.ts";
 export * from "./useMyShops.ts";
 export * from "./useIsOwner.ts";
+export * from "./useOrderItemsInventory.ts";

--- a/packages/react-hooks/useActiveOrder.ts
+++ b/packages/react-hooks/useActiveOrder.ts
@@ -78,7 +78,7 @@ export function useActiveOrder(params?: HookParams): UseActiveOrderReturn {
   }
 
   async function cancelAndRecreateOrder() {
-    logger.debug("Cancelling and recreating order");
+    logger.debug(`Cancelling order ${activeOrder!.ID} and recreating order`);
     const items = activeOrder?.Items;
     await cancelOrder();
     const newOrderID = randUint64();
@@ -92,7 +92,7 @@ export function useActiveOrder(params?: HookParams): UseActiveOrderReturn {
       ["Orders", newOrderID],
       newOrder,
     );
-    logger.debug("Order recreated.");
+    logger.debug(`New order created: ${newOrderID}`);
     return newOrderID;
   }
 

--- a/packages/react-hooks/useOrderItemsInventory.ts
+++ b/packages/react-hooks/useOrderItemsInventory.ts
@@ -16,7 +16,7 @@ const baseLogger = getLogger([
  * This hook is used to get the inventory for all the items in current/active order.
  * It listens to inventory updates for those items.
  */
-export default function useOrderItemsInventory() {
+export function useOrderItemsInventory() {
   const { stateManager } = useStateManager();
   const { activeOrder } = useActiveOrder();
   const [inventoryMap, setInventoryMap] = useState<Map<number, number>>(
@@ -30,7 +30,7 @@ export default function useOrderItemsInventory() {
   useEffect(() => {
     if (!listingIds || !stateManager) return;
     const updateInventoryMap = new Map();
-    activeOrder?.Items.forEach((item) => {
+    activeOrder!.Items.forEach((item) => {
       stateManager.get(["Inventory", item.ListingID]).then((stockNo) => {
         updateInventoryMap.set(item.ListingID, stockNo);
       });
@@ -46,11 +46,9 @@ export default function useOrderItemsInventory() {
         if (typeof stockNo !== "number") {
           logger.error("Inventory is not a number");
         }
-        setInventoryMap((prev) => {
-          const updatedInventoryMap = new Map(prev);
-          updatedInventoryMap.set(key, stockNo as number);
-          return updatedInventoryMap;
-        });
+        const m = new Map(inventoryMap);
+        m.set(key, stockNo as number);
+        setInventoryMap(m);
       };
 
       // Store the handler reference so we can remove it after
@@ -68,7 +66,7 @@ export default function useOrderItemsInventory() {
         stateManager.events.off(handler, ["Inventory", key]);
       });
     };
-  }, [listingIds, stateManager]);
+  }, [activeOrder, !!stateManager]);
 
   return { inventoryMap };
 }

--- a/packages/react-hooks/useOrderItemsInventory.ts
+++ b/packages/react-hooks/useOrderItemsInventory.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { getLogger } from "@logtape/logtape";
+
+import type { CodecValue } from "@massmarket/utils/codec";
+
+import { useStateManager } from "./useStateManager.ts";
+import { useActiveOrder } from "./useActiveOrder.ts";
+
+const baseLogger = getLogger([
+  "mass-market",
+  "frontend",
+  "useOrderItemsInventory",
+]);
+
+/**
+ * This hook is used to get the inventory for all the items in current/active order.
+ * It listens to inventory updates for those items.
+ */
+export default function useOrderItemsInventory() {
+  const { stateManager } = useStateManager();
+  const { activeOrder } = useActiveOrder();
+  const [inventoryMap, setInventoryMap] = useState<Map<number, number>>(
+    new Map(),
+  );
+  const listingIds = activeOrder?.Items.map((item) => item.ListingID);
+  const logger = baseLogger.with({
+    orderId: activeOrder?.ID,
+  });
+
+  useEffect(() => {
+    if (!listingIds || !stateManager) return;
+    const updateInventoryMap = new Map();
+    activeOrder?.Items.forEach((item) => {
+      stateManager.get(["Inventory", item.ListingID]).then((stockNo) => {
+        updateInventoryMap.set(item.ListingID, stockNo);
+      });
+    });
+    setInventoryMap(updateInventoryMap);
+
+    // Setting up event listeners for inventory updates.
+    // Create a map to store event handlers for each key.
+    const eventHandlers = new Map();
+
+    listingIds.forEach((key: number) => {
+      const onInventoryUpdate = (stockNo: CodecValue | undefined) => {
+        if (typeof stockNo !== "number") {
+          logger.error("Inventory is not a number");
+        }
+        setInventoryMap((prev) => {
+          const updatedInventoryMap = new Map(prev);
+          updatedInventoryMap.set(key, stockNo as number);
+          return updatedInventoryMap;
+        });
+      };
+
+      // Store the handler reference so we can remove it after
+      eventHandlers.set(key, onInventoryUpdate);
+
+      stateManager.events.on(onInventoryUpdate, ["Inventory", key]);
+    });
+    return () => {
+      listingIds.forEach((key) => {
+        const handler = eventHandlers.get(key);
+        if (!handler) {
+          logger.error(`Handler for ${key} not found`);
+          return;
+        }
+        stateManager.events.off(handler, ["Inventory", key]);
+      });
+    };
+  }, [listingIds, stateManager]);
+
+  return { inventoryMap };
+}

--- a/packages/react-hooks/useOrderItemsInventory_test.ts
+++ b/packages/react-hooks/useOrderItemsInventory_test.ts
@@ -12,7 +12,7 @@ import {
   denoTestOptions,
   testWrapper,
 } from "./_createWrapper.tsx";
-import useOrderItemsInventory from "./useOrderItemsInventory.ts";
+import { useOrderItemsInventory } from "./useOrderItemsInventory.ts";
 
 Deno.test(
   "useOrderItemsInventory",

--- a/packages/react-hooks/useOrderItemsInventory_test.ts
+++ b/packages/react-hooks/useOrderItemsInventory_test.ts
@@ -1,0 +1,74 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { expect } from "@std/expect";
+
+import { allListings } from "@massmarket/schema/testFixtures";
+import { randUint64 } from "@massmarket/utils";
+import { Order, OrderedItem, OrderPaymentState } from "@massmarket/schema";
+
+import {
+  createTestRelayClient,
+  createTestStateManager,
+  createWrapper,
+  denoTestOptions,
+  testWrapper,
+} from "./_createWrapper.tsx";
+import useOrderItemsInventory from "./useOrderItemsInventory.ts";
+
+Deno.test(
+  "useOrderItemsInventory",
+  denoTestOptions,
+  testWrapper(async (shopId, t) => {
+    const relayClient = await createTestRelayClient(shopId);
+    const stateManager = await createTestStateManager(shopId);
+    const listingId = 23;
+    const listingId2 = 42;
+    await t.step("Create listings and new open order", async () => {
+      await relayClient.connect();
+      await relayClient.authenticate();
+      stateManager.addConnection(relayClient);
+      for (const [key, entry] of allListings.entries()) {
+        await stateManager.set(["Listings", key], entry);
+        if (key === listingId) {
+          await stateManager.set(["Inventory", key], 111);
+        } else {
+          await stateManager.set(["Inventory", key], 122);
+        }
+      }
+
+      const orderId = randUint64();
+
+      const newOrder = new Order(
+        orderId,
+        [
+          new OrderedItem(listingId, 5),
+          new OrderedItem(listingId2, 5),
+        ],
+        OrderPaymentState.Open,
+      );
+      await stateManager!.set(
+        ["Orders", orderId],
+        newOrder,
+      );
+    });
+
+    await t.step("Test useOrderItemsInventory", async () => {
+      const { result, unmount } = renderHook(() => useOrderItemsInventory(), {
+        wrapper: createWrapper(shopId),
+      });
+      await waitFor(() => {
+        expect(result.current.inventoryMap.size).toBe(2);
+        expect(result.current.inventoryMap.get(listingId)).toBe(111);
+        expect(result.current.inventoryMap.get(listingId2)).toBe(122);
+      });
+      // Fire inventory update events and verify the event listeners are set up correctly.
+      await stateManager.set(["Inventory", listingId], 999);
+      await stateManager.set(["Inventory", listingId2], 888);
+
+      await waitFor(() => {
+        expect(result.current.inventoryMap.get(listingId)).toBe(999);
+        expect(result.current.inventoryMap.get(listingId2)).toBe(888);
+      });
+      unmount();
+    });
+  }),
+);


### PR DESCRIPTION
separating out the logic that retrieves inventory for all the items in the current/active order into a hook, because I need to use this in various components